### PR TITLE
Remove ZWSP characters found in source code, align compiler version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </licenses>
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <main.java.package>io.phasetwo.service</main.java.package>
     <junit.version>4.13.2</junit.version>

--- a/src/main/java/io/phasetwo/service/auth/IdpAuthenticator.java
+++ b/src/main/java/io/phasetwo/service/auth/IdpAuthenticator.java
@@ -17,10 +17,10 @@ import org.keycloak.provider.ProviderEvent;
 public class IdpAuthenticator extends AbstractIdpAuthenticator implements DefaultAuthenticator {
 
   @Override
-  public void authenticateImpl​(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext) {
+  public void authenticateImpl(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext) {
   }
 
   @Override
-  public void actionImpl​(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext) {
+  public void actionImpl(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext) {
   }  
 }

--- a/src/main/java/io/phasetwo/service/resource/IdentityProvidersResource.java
+++ b/src/main/java/io/phasetwo/service/resource/IdentityProvidersResource.java
@@ -71,7 +71,7 @@ public class IdentityProvidersResource extends OrganizationAdminResource {
     representation.getConfig().put("syncMode", "FORCE");
     representation.getConfig().put("hideOnLoginPage", "true");
     representation.getConfig().put(ORG_OWNER_CONFIG_KEY, organization.getId());
-    representation.setPostBrokerLoginFlowAlias​(ORG_AUTH_FLOW_ALIAS);
+    representation.setPostBrokerLoginFlowAlias(ORG_AUTH_FLOW_ALIAS);
     //  - firstBrokerLoginFlowAlias
   }
 


### PR DESCRIPTION
While reviewing your code I found out that there are extra characters which make intellij report errors, even if command line build worked fine. I removed them, even if diff does not show them. I did switch `java.version` property from 1.8 as your code already use `Optional.isEmpty` which is added in Java 11.