### PR TITLE
Add support for MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Then, checkout this project and run `mvn package`, which will produce a jar in t
 The maven build uses the shade plugin to package a fat-jar with all dependencies, except for the [`keycloak-admin-client`](https://mvnrepository.com/artifact/org.keycloak/keycloak-admin-client). Put the `keycloak-orgs` jar and `keycloak-admin-client` jar (that corresponds to your Keycloak version) in your `provider` (for Quarkus-based distribution) or in `standalone/deployments` (for Wildfly, legacy distribution) directory and restart Keycloak. It is unknown if these extensions will work with hot reloading using the legacy distribution.
 
 During the first run, some initial migrations steps will occur:
-- Database migrations will be run to add the tables for use by the JPA entities. These have been tested with H2 and Postgres. Other database types may fail.
+- Database migrations will be run to add the tables for use by the JPA entities. These have been tested with MySQL, H2, and Postgres. Other database types may fail.
 - Initial `realm-management` client roles (`view-organizations` and `manage-organizations`) will be be added to each realm.
 
 ### Compatibility

--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-20200611-1.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-20200611-1.xml
@@ -1,9 +1,29 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
     <changeSet author="garth" id="20200611-1-0">
-      <renameColumn columnDataType="VARCHAR(36)"  
-		    newColumnName="TEAM_ID"  
-		    oldColumnName="teams_ID"  
-		    tableName="INVITATION_TEAM"/>  
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <dbms type="mysql"/>
+            </not>
+        </preConditions>
+        <renameColumn columnDataType="VARCHAR(36)"
+            newColumnName="TEAM_ID"
+            oldColumnName="teams_ID"
+            tableName="INVITATION_TEAM"/>
+    </changeSet>
+
+    <!-- mysql specific -->
+    <changeSet author="garth" id="20200611-1-">
+        <preConditions onFail="MARK_RAN">
+            <dbms type="mysql"/>
+        </preConditions>
+        <dropForeignKeyConstraint baseTableName="INVITATION_TEAM" constraintName="FK_lhea5u4vqt3n9694kq7hyl5at"/>
+        <dropUniqueConstraint tableName="INVITATION_TEAM" constraintName="UK_lhea5u4vqt3n9694kq7hyl5at"/>
+        <renameColumn columnDataType="VARCHAR(36)"
+            newColumnName="TEAM_ID"
+            oldColumnName="teams_ID"
+            tableName="INVITATION_TEAM"/>
+        <addUniqueConstraint columnNames="TEAM_ID" constraintName="UK_lhea5u4vqt3n9694kq7hyl5at" tableName="INVITATION_TEAM"/>
+        <addForeignKeyConstraint baseColumnNames="TEAM_ID" baseTableName="INVITATION_TEAM" constraintName="FK_lhea5u4vqt3n9694kq7hyl5at" deferrable="false" initiallyDeferred="false" referencedColumnNames="ID" referencedTableName="TEAM"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-20211208.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-20211208.xml
@@ -2,15 +2,32 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
   <changeSet author="garth" id="drop-column-user-org-role-org-0">
-    <dropUniqueConstraint  catalogName="cat"  
+    <preConditions onFail="MARK_RAN">
+        <not>
+            <dbms type="mysql"/>
+        </not>
+    </preConditions>
+    <dropUniqueConstraint
             constraintName="UK_S5FNFVSRU9I4QPH9GB8V4FXFM"
-            tableName="USER_ORGANIZATION_ROLE_MAPPING"  
-            uniqueColumns="ORGANIZATION_ID, USER_ID, ROLE_ID"/>  
+            tableName="USER_ORGANIZATION_ROLE_MAPPING"
+            uniqueColumns="ORGANIZATION_ID, USER_ID, ROLE_ID"/>
   </changeSet>
-  
+
+  <!-- mysql specific -->
+  <changeSet author="garth" id="drop-column-user-org-role-org-0-1">
+    <preConditions onFail="MARK_RAN">
+      <dbms type="mysql"/>
+    </preConditions>
+    <dropForeignKeyConstraint baseTableName="USER_ORGANIZATION_ROLE_MAPPING" constraintName="FK_HGF6S4UUNYWDKP4244YTNGBAD"/>
+    <dropUniqueConstraint
+            constraintName="UK_S5FNFVSRU9I4QPH9GB8V4FXFM"
+            tableName="USER_ORGANIZATION_ROLE_MAPPING"
+            uniqueColumns="ORGANIZATION_ID, USER_ID, ROLE_ID"/>
+  </changeSet>
+
   <changeSet author="garth" id="drop-column-user-org-role-org-1">
-    <dropColumn tableName="USER_ORGANIZATION_ROLE_MAPPING">  
-      <column  name="ORGANIZATION_ID"/>  
+    <dropColumn tableName="USER_ORGANIZATION_ROLE_MAPPING">
+      <column  name="ORGANIZATION_ID"/>
     </dropColumn>
   </changeSet>
 

--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-20220221.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-20220221.xml
@@ -2,8 +2,21 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
   <changeSet author="garth" id="org-name-unique-constraint-drop">
+    <preConditions onFail="MARK_RAN">
+        <not>
+            <dbms type="mysql"/>
+        </not>
+    </preConditions>
+    <dropUniqueConstraint constraintName="UK_19A0TR48O23ALOR84GB8E3GC2" tableName="ORGANIZATION_ATTRIBUTE"/>
+  </changeSet>
+
+  <!-- mysql specific -->
+  <changeSet author="garth" id="org-name-unique-constraint-drop-1">
+    <preConditions onFail="MARK_RAN">
+        <dbms type="mysql"/>
+    </preConditions>
+    <dropForeignKeyConstraint baseTableName="ORGANIZATION_ATTRIBUTE" constraintName="FK_519erdjtqivq189pm1ouanaix"/>
     <dropUniqueConstraint constraintName="UK_19A0TR48O23ALOR84GB8E3GC2" tableName="ORGANIZATION_ATTRIBUTE"/>
   </changeSet>
 
 </databaseChangeLog>
-      


### PR DESCRIPTION
Fixes: #42 

This PR adds MySQL support by refactoring the existing database migrations to add MySQL-specific changesets. This has been tested on MySQL 5.7 and 8 (the two most prominent releases).

MySQL is generally more strict when it comes to altering or dropping columns with existing foreign key and uniqueness constraints attached to them; therefore, you need to be more explicit and also drop the constraints before your operation. Postgres is more "intelligent" when it comes to this and knows when to cascade FK relationships down and thus does this for you implicitly, hence why the migrations in their current form work. 

This also follows the same pattern used by Keycloak core, an example of which can be found [here](https://github.com/keycloak/keycloak/blob/b9ab942ef875c4944f659369e07aa275be6ada4c/model/jpa/src/main/resources/META-INF/jpa-changelog-1.2.0.CR1.xml#L139-L141). However, while these changes are considered "safe", I opted not to impact the existing migrations and wrapped any mysql-specfic operations in their own `chanegSet`'s guarded with `preCondition`'s, much like you've already done for cockroach in a few places. 

Let me know if you want anything changed, and once again, thank you for the great extension :)

--- 

For further context, here's a couple of example errors thrown by mysql/liquibase without this changes:

```
Reason: liquibase.exception.DatabaseException: ALGORITHM=COPY is not supported. Reason: Columns participating in a foreign key are renamed. Try ALGORITHM=INPLACE. 
```

```
Reason: liquibase.exception.DatabaseException: Cannot drop index 'UK_S5FNFVSRU9I4QPH9GB8V4FXFM': needed in a foreign key constraint [Failed SQL: (1553) ALTER TABLE keycloak.USER_ORGANIZATION_ROLE_MAPPING DROP KEY UK_S5FNFVSRU9I4QPH9GB8V4FXFM]
```