### PR TITLE
simplify integration tests

### DIFF
--- a/src/test/java/io/phasetwo/service/openapi/PhaseTwo.java
+++ b/src/test/java/io/phasetwo/service/openapi/PhaseTwo.java
@@ -1,0 +1,54 @@
+package io.phasetwo.service.openapi;
+
+import io.phasetwo.service.KeycloakSuite;
+import io.phasetwo.service.openapi.api.*;
+import org.keycloak.admin.client.Keycloak;
+
+import java.net.URI;
+
+public class PhaseTwo {
+
+  private final Keycloak keycloak;
+  private final URI absoluteUri;
+
+  public PhaseTwo(KeycloakSuite suite) {
+    this(suite.client(), suite.getAuthUrl());
+  }
+
+  public PhaseTwo(Keycloak keycloak, String absoluteUrl) {
+    this.keycloak = keycloak;
+    this.absoluteUri = URI.create(absoluteUrl).resolve("/auth/realms");
+  }
+
+  private  <T> T buildApi(Class<T> targetClass) {
+    return keycloak.proxy(targetClass, absoluteUri);
+  }
+
+  public OrganizationInvitationsApi invitations() {
+    return buildApi(OrganizationInvitationsApi.class);
+  }
+
+  public UsersApi users() {
+    return buildApi(UsersApi.class);
+  }
+
+  public OrganizationRolesApi roles() {
+    return buildApi(OrganizationRolesApi.class);
+  }
+
+  public OrganizationMembershipsApi members() {
+    return buildApi(OrganizationMembershipsApi.class);
+  }
+
+  public OrganizationsApi organizations() {
+    return buildApi(OrganizationsApi.class);
+  }
+
+  public IdentityProvidersApi idps() {
+    return buildApi(IdentityProvidersApi.class);
+  }
+
+  public OrganizationDomainsApi domains() {
+    return buildApi(OrganizationDomainsApi.class);
+  }
+}

--- a/src/test/java/io/phasetwo/service/openapi/api/IdentityProvidersApi.java
+++ b/src/test/java/io/phasetwo/service/openapi/api/IdentityProvidersApi.java
@@ -1,0 +1,72 @@
+package io.phasetwo.service.openapi.api;
+
+import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+
+@Path("/{realm}/orgs/{orgId}/idps")
+public interface IdentityProvidersApi {
+
+    @POST
+    @Path("/{alias}/mappers")
+    @Consumes({ "application/json" })
+    Response addIdpMapper(@PathParam("realm") String realm, @PathParam("orgId") String orgId, @PathParam("alias") String alias, IdentityProviderMapperRepresentation identityProviderMapperRepresentation);
+
+    @POST
+    @Consumes({ "application/json" })
+    Response createIdp(@PathParam("realm") String realm, @PathParam("orgId") String orgId, IdentityProviderRepresentation identityProviderRepresentation);
+
+    @DELETE
+    @Path("/{alias}")
+    Response deleteIdp(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("alias") String alias);
+
+    @DELETE
+    @Path("/{alias}/mappers/{id}")
+    Response deleteIdpMapper(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("alias") String alias,@PathParam("id") String id);
+
+    @GET
+    @Path("/{alias}")
+    @Produces({ "application/json" })
+    Response getIdp(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("alias") String alias);
+
+    @GET
+    @Path("/{alias}/mappers/{id}")
+    @Produces({ "application/json" })
+    Response getIdpMapper(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("alias") String alias,@PathParam("id") String id);
+
+    @GET
+    @Path("/{alias}/mappers")
+    @Produces({ "application/json" })
+    Response getIdpMappers(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("alias") String alias);
+
+    @GET
+    @Produces({ "application/json" })
+    Response getIdps(@PathParam("realm") String realm,@PathParam("orgId") String orgId);
+
+    @POST
+    @Path("/import-config")
+    @Produces({ "application/json" })
+    @Consumes({ "application/json" })
+    Response importIdpJson(@PathParam("realm") String realm,@PathParam("orgId") String orgId,Map<String, String> body);
+
+    @PUT
+    @Path("/{alias}")
+    @Consumes({ "application/json" })
+    Response updateIdp(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("alias") String alias,IdentityProviderRepresentation identityProviderRepresentation);
+
+    @PUT
+    @Path("/{alias}/mappers/{id}")
+    @Consumes({ "application/json" })
+    Response updateIdpMapper(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("alias") String alias,@PathParam("id") String id,IdentityProviderMapperRepresentation identityProviderMapperRepresentation);
+}

--- a/src/test/java/io/phasetwo/service/openapi/api/OrganizationDomainsApi.java
+++ b/src/test/java/io/phasetwo/service/openapi/api/OrganizationDomainsApi.java
@@ -1,0 +1,25 @@
+package io.phasetwo.service.openapi.api;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+@Path("/{realm}/orgs/{orgId}/domains")
+public interface OrganizationDomainsApi {
+
+    @GET
+    @Path("/{domainName}")
+    @Produces({ "application/json" })
+    Response getOrganizationDomain(@PathParam("realm") String realm, @PathParam("orgId") String orgId, @PathParam("domainName") String domainName);
+
+    @GET
+    @Produces({ "application/json" })
+    Response getOrganizationDomains(@PathParam("realm") String realm,@PathParam("orgId") String orgId);
+
+    @POST
+    @Path("/{domainName}/verify")
+    Response verifyDomain(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("domainName") String domainName);
+}

--- a/src/test/java/io/phasetwo/service/openapi/api/OrganizationInvitationsApi.java
+++ b/src/test/java/io/phasetwo/service/openapi/api/OrganizationInvitationsApi.java
@@ -1,0 +1,33 @@
+package io.phasetwo.service.openapi.api;
+
+import io.phasetwo.service.representation.InvitationRequest;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+@Path("/{realm}/orgs/{orgId}/invitations")
+public interface OrganizationInvitationsApi {
+
+    @POST
+    @Consumes({ "application/json" })
+    Response addOrganizationInvitation(@PathParam("realm") String realm, @PathParam("orgId") String orgId, InvitationRequest invitationRequestRepresentation);
+
+    @GET
+    @Produces({ "application/json" })
+    Response getOrganizationInvitations(@PathParam("realm") String realm,@PathParam("orgId") String orgId);
+
+    @GET
+    @Produces({ "application/json" })
+    Response getOrganizationInvitations(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@QueryParam("search")   String search,@QueryParam("first")   Integer first,@QueryParam("max")   Integer max);
+
+    @DELETE
+    @Path("/{invitationId}")
+    Response removeOrganizationInvitation(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("invitationId") String invitationId);
+}

--- a/src/test/java/io/phasetwo/service/openapi/api/OrganizationMembershipsApi.java
+++ b/src/test/java/io/phasetwo/service/openapi/api/OrganizationMembershipsApi.java
@@ -1,0 +1,34 @@
+package io.phasetwo.service.openapi.api;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+@Path("/{realm}/orgs/{orgId}/members")
+public interface OrganizationMembershipsApi {
+
+    @PUT
+    @Path("/{userId}")
+    Response addOrganizationMember(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("userId") String userId);
+
+    @GET
+    @Path("/{userId}")
+    Response checkOrganizationMembership(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("userId") String userId);
+
+    @GET
+    @Produces({ "application/json" })
+    Response getOrganizationMemberships(@PathParam("realm") String realm,@PathParam("orgId") String orgId);
+
+    @GET
+    @Produces({ "application/json" })
+    Response getOrganizationMemberships(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@QueryParam("first")   Integer first,@QueryParam("max")   Integer max);
+
+    @DELETE
+    @Path("/{userId}")
+    Response removeOrganizationMember(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("userId") String userId);
+}

--- a/src/test/java/io/phasetwo/service/openapi/api/OrganizationRolesApi.java
+++ b/src/test/java/io/phasetwo/service/openapi/api/OrganizationRolesApi.java
@@ -1,0 +1,56 @@
+package io.phasetwo.service.openapi.api;
+
+import io.phasetwo.service.representation.OrganizationRole;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+@Path("/{realm}/orgs/{orgId}/roles")
+public interface OrganizationRolesApi {
+
+    @GET
+    @Path("/{name}/users/{userId}")
+    Response checkUserOrganizationRole(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("name") String name,@PathParam("userId") String userId);
+
+    @POST
+    @Consumes({ "application/json" })
+    Response createOrganizationRole(@PathParam("realm") String realm, @PathParam("orgId") String orgId, OrganizationRole organizationRoleRepresentation);
+
+    @DELETE
+    @Path("/{name}")
+    Response deleteOrganizationRole(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("name") String name);
+
+    @GET
+    @Path("/{name}")
+    @Produces({ "application/json" })
+    Response getOrganizationRole(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("name") String name);
+
+    @GET
+    @Produces({ "application/json" })
+    Response getOrganizationRoles(@PathParam("realm") String realm,@PathParam("orgId") String orgId);
+
+    @GET
+    @Path("/{name}/users")
+    @Produces({ "application/json" })
+    Response getUserOrganizationRoles(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("name") String name);
+
+    @PUT
+    @Path("/{name}/users/{userId}")
+    Response grantUserOrganizationRole(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("name") String name,@PathParam("userId") String userId);
+
+    @DELETE
+    @Path("/{name}/users/{userId}")
+    Response revokeUserOrganizationRole(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("name") String name,@PathParam("userId") String userId);
+
+    @PUT
+    @Path("/{name}")
+    @Consumes({ "application/json" })
+    Response updateOrganizationRole(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@PathParam("name") String name,OrganizationRole organizationRoleRepresentation);
+}

--- a/src/test/java/io/phasetwo/service/openapi/api/OrganizationsApi.java
+++ b/src/test/java/io/phasetwo/service/openapi/api/OrganizationsApi.java
@@ -1,0 +1,47 @@
+package io.phasetwo.service.openapi.api;
+
+import io.phasetwo.service.representation.Organization;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+@Path("/{realm}/orgs")
+public interface OrganizationsApi {
+
+    @POST
+    @Consumes({ "application/json" })
+    Response createOrganization(@PathParam("realm") String realm, Organization organizationRepresentation);
+
+    @POST
+    @Path("/{orgId}/portal-link")
+    @Consumes({ "application/x-www-form-urlencoded" })
+    @Produces({ "application/json" })
+    Response createPortalLink(@PathParam("realm") String realm,@PathParam("orgId") String orgId,@FormParam(value = "userId")  String userId);
+
+    @DELETE
+    @Path("/{orgId}")
+    Response deleteOrganization(@PathParam("realm") String realm,@PathParam("orgId") String orgId);
+
+    @GET
+    @Path("/{orgId}")
+    @Produces({ "application/json" })
+    Response  getOrganizationById(@PathParam("realm") String realm,@PathParam("orgId") String orgId);
+
+    @GET
+    @Produces({ "application/json" })
+    Response getOrganizations(@PathParam("realm") String realm,@QueryParam("search")   String search,@QueryParam("first")   Integer first,@QueryParam("max")   Integer max);
+
+    @PUT
+    @Path("/{orgId}")
+    @Consumes({ "application/json" })
+    Response updateOrganization(@PathParam("realm") String realm,@PathParam("orgId") String orgId,Organization organizationRepresentation);
+}

--- a/src/test/java/io/phasetwo/service/openapi/api/UsersApi.java
+++ b/src/test/java/io/phasetwo/service/openapi/api/UsersApi.java
@@ -1,0 +1,21 @@
+package io.phasetwo.service.openapi.api;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+@Path("/{realm}")
+public interface UsersApi {
+
+    @GET
+    @Path("/users/{userId}/orgs")
+    @Produces({ "application/json" })
+    Response realmUsersUserIdOrgsGet(@PathParam("realm") String realm,@PathParam("userId") String userId);
+
+    @GET
+    @Path("/users/{userId}/orgs/{orgId}/roles")
+    @Produces({ "application/json" })
+    Response realmUsersUserIdOrgsOrgIdRolesGet(@PathParam("realm") String realm,@PathParam("userId") String userId,@PathParam("orgId") String orgId);
+}

--- a/src/test/java/io/phasetwo/service/resource/AbstractResourceTest.java
+++ b/src/test/java/io/phasetwo/service/resource/AbstractResourceTest.java
@@ -1,0 +1,89 @@
+package io.phasetwo.service.resource;
+
+import io.phasetwo.service.KeycloakSuite;
+import io.phasetwo.service.openapi.PhaseTwo;
+import io.phasetwo.service.openapi.api.OrganizationRolesApi;
+import io.phasetwo.service.openapi.api.OrganizationsApi;
+import io.phasetwo.service.representation.Organization;
+import io.phasetwo.service.representation.OrganizationRole;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.ClassRule;
+import org.keycloak.admin.client.Keycloak;
+
+import javax.ws.rs.core.Response;
+
+import static io.phasetwo.service.Helpers.urlencode;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+public abstract class AbstractResourceTest {
+
+  public static final String REALM = "master";
+
+  @ClassRule
+  public static KeycloakSuite server = KeycloakSuite.SERVER;
+
+  public static PhaseTwo phaseTwo() {
+    return phaseTwo(server.client());
+  }
+  public static PhaseTwo phaseTwo(Keycloak keycloak) {
+    return new PhaseTwo(keycloak, server.getAuthUrl());
+  }
+
+  protected String url(String realm, String... segments) {
+    StringBuilder o = new StringBuilder();
+    for (String segment : segments) {
+      o.append("/").append(segment);
+    }
+    return String.format("%s/realms/%s/orgs%s", server.getAuthUrl(), realm, o);
+  }
+
+  protected String createRole(OrganizationRolesApi api, String orgId, String name) {
+    OrganizationRole rep = new OrganizationRole().name(name);
+    try(Response response = api.createOrganizationRole(REALM, orgId, rep)) {
+      assertThat(response.getStatus(), is(201));
+      assertNotNull(response.getHeaderString("Location"));
+      String loc = response.getHeaderString("Location");
+      String id = loc.substring(loc.lastIndexOf("/") + 1);
+      assertThat(name, is(id));
+      assertThat(loc, is(url(REALM, urlencode(orgId), "roles", id)));
+      return id;
+    }
+  }
+
+  protected void grantUserRole(OrganizationRolesApi api, String orgId, String role, String userId) {
+    try(Response response = api.grantUserOrganizationRole(REALM, orgId, role, userId)) {
+      assertThat(response.getStatus(), is(201));
+      assertNotNull(response.getHeaderString("Location"));
+      String loc = response.getHeaderString("Location");
+      assertThat(loc, is(url(REALM, urlencode(orgId), "roles", urlencode(role), "users", userId)));
+    }
+  }
+
+  protected void checkUserRole(OrganizationRolesApi api, String orgId, String role, String userId, int status) {
+    // check if user has role
+    try(Response response = api.checkUserOrganizationRole(REALM, orgId, role, userId)) {
+      assertThat(response.getStatus(), is(status));
+    }
+  }
+
+  protected String createOrg(OrganizationsApi api, String realm, Organization rep) {
+    try(Response response = api.createOrganization(realm, rep)) {
+      assertThat(response.getStatus(), is(201));
+      assertNotNull(response.getHeaderString("Location"));
+      String loc = response.getHeaderString("Location");
+      String id = loc.substring(loc.lastIndexOf("/") + 1);
+      assertNotNull(id);
+      assertThat(loc, is(url(realm, id)));
+      return id;
+    }
+  }
+
+  protected void deleteOrg(OrganizationsApi api, String realm, String orgId) {
+    try(Response response = api.deleteOrganization(realm, orgId)) {
+      assertThat(response.getStatus(), is(204));
+    }
+  }
+}


### PR DESCRIPTION
I copypasted openapi specifications from [phasetwo-admin-client](https://mvnrepository.com/artifact/io.phasetwo/phasetwo-admin-client/0.0.2). 
I think it's much easier than `SimpleHttp.Response`
Return type for method signatures replaced to `Response` for proper status/headers validation;