### PR TITLE
doc(README.md): Add Theme settings in Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The maven build uses the shade plugin to package a fat-jar with all dependencies
 During the first run, some initial migrations steps will occur:
 - Database migrations will be run to add the tables for use by the JPA entities. These have been tested with H2 and Postgres. Other database types may fail.
 - Initial `realm-management` client roles (`view-organizations` and `manage-organizations`) will be be added to each realm.
+- In Admin Console, Go to `Realm Settings` -> `Themes` page and select `phasetwo.v2`. Then "Organizations" section will be available in the left navigation.
 
 ### Compatibility
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ The maven build uses the shade plugin to package a fat-jar with all dependencies
 During the first run, some initial migrations steps will occur:
 - Database migrations will be run to add the tables for use by the JPA entities. These have been tested with H2 and Postgres. Other database types may fail.
 - Initial `realm-management` client roles (`view-organizations` and `manage-organizations`) will be be added to each realm.
-- In Admin Console, Go to `Realm Settings` -> `Themes` page and select `phasetwo.v2`. Then "Organizations" section will be available in the left navigation.
+
+### Admin UI
+If you are using the extension as bundled in the [Docker image](https://quay.io/repository/phasetwo/phasetwo-keycloak?tab=tags) or by building our [Admin UI theme](https://github.com/p2-inc/keycloak-ui), you must take an additional step in order to show that theme. In the Admin Console UI, go to the *Realm Settings* -> *Themes* page and select `phasetwo.v2`. Then, the "Organizations" section will be available in the left navigation.
 
 ### Compatibility
 


### PR DESCRIPTION
When I firstly switch to P2 Keycloak Docker image from existing Keycloak Deployment. I could not notice any changes in Admin page. This commit should reduce confusions like this.