### PR TITLE
Add the ability to search for organizations by their attributes

### DIFF
--- a/src/main/java/io/phasetwo/service/model/OrganizationProvider.java
+++ b/src/main/java/io/phasetwo/service/model/OrganizationProvider.java
@@ -1,5 +1,6 @@
 package io.phasetwo.service.model;
 
+import java.util.Map;
 import java.util.stream.Stream;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -15,6 +16,9 @@ public interface OrganizationProvider extends Provider {
   Stream<OrganizationModel> getOrganizationsStream(
       RealmModel realm, Integer firstResult, Integer maxResults);
 
+  Stream<OrganizationModel> getOrganizationsStream(
+      RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults);
+
   default Stream<OrganizationModel> getOrganizationsStream(RealmModel realm) {
     return getOrganizationsStream(realm, null, null);
   }
@@ -24,6 +28,9 @@ public interface OrganizationProvider extends Provider {
 
   Stream<OrganizationModel> searchForOrganizationByNameStream(
       RealmModel realm, String search, Integer firstResult, Integer maxResults);
+
+  Stream<OrganizationModel> searchForOrganizationByAttributesStream(
+      RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults);
 
   Stream<OrganizationModel> getUserOrganizationsStream(RealmModel realm, UserModel user);
 

--- a/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java
+++ b/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java
@@ -247,13 +247,21 @@ public class JpaOrganizationProvider implements OrganizationProvider {
         continue;
       }
 
-      Join<OrganizationEntity, OrganizationAttributeEntity> attributesJoin =
-          root.join("attributes", JoinType.LEFT);
+      switch (key) {
+        case "name":
+          predicates.add(builder.like(root.get(key), "%" + value.toLowerCase() + "%"));
+          break;
+          // All unknown attributes will be assumed as custom attributes.
+        default:
+          Join<OrganizationEntity, OrganizationAttributeEntity> attributesJoin =
+              root.join("attributes", JoinType.LEFT);
 
-      attributePredicates.add(
-          builder.and(
-              builder.equal(builder.lower(attributesJoin.get("name")), key.toLowerCase()),
-              builder.equal(builder.lower(attributesJoin.get("value")), value.toLowerCase())));
+          attributePredicates.add(
+              builder.and(
+                  builder.equal(builder.lower(attributesJoin.get("name")), key.toLowerCase()),
+                  builder.equal(builder.lower(attributesJoin.get("value")), value.toLowerCase())));
+          break;
+      }
     }
 
     if (!attributePredicates.isEmpty()) {

--- a/src/main/java/io/phasetwo/service/resource/OrganizationsResource.java
+++ b/src/main/java/io/phasetwo/service/resource/OrganizationsResource.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.phasetwo.service.model.OrganizationModel;
 import io.phasetwo.service.representation.Organization;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -19,6 +20,7 @@ import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.utils.SearchQueryUtils;
 
 @JBossLog
 public class OrganizationsResource extends OrganizationAdminResource {
@@ -68,13 +70,31 @@ public class OrganizationsResource extends OrganizationAdminResource {
   @Path("")
   @Produces(MediaType.APPLICATION_JSON)
   public Stream<Organization> listOrgs(
-      @QueryParam("search") String searchQuery,
+      @QueryParam("search") String search,
       @QueryParam("first") Integer firstResult,
-      @QueryParam("max") Integer maxResults) {
-    log.debugf("listOrgs %s %s %d %d", realm.getName(), searchQuery, firstResult, maxResults);
+      @QueryParam("max") Integer maxResults,
+      @QueryParam("q") String searchQuery) {
     firstResult = firstResult != null ? firstResult : 0;
     maxResults = maxResults != null ? maxResults : Constants.DEFAULT_MAX_RESULTS;
-    return orgs.searchForOrganizationByNameStream(realm, searchQuery, firstResult, maxResults)
+
+    if (search != null && searchQuery != null) {
+      throw new BadRequestException("Only one of search or q can be provided.");
+    }
+
+    if (searchQuery != null) {
+      log.debugf("listOrgs %s %s %d %d", realm.getName(), searchQuery, firstResult, maxResults);
+
+      Map<String, String> searchAttributes =
+          searchQuery == null ? Collections.emptyMap() : SearchQueryUtils.getFields(searchQuery);
+
+      return orgs.searchForOrganizationByAttributesStream(
+              realm, searchAttributes, firstResult, maxResults)
+          .filter(m -> (auth.hasViewOrgs() || auth.hasOrgViewOrg(m)))
+          .map(m -> convertOrganizationModelToOrganization(m));
+    }
+
+    log.debugf("listOrgs %s %s %d %d", realm.getName(), search, firstResult, maxResults);
+    return orgs.searchForOrganizationByNameStream(realm, search, firstResult, maxResults)
         .filter(m -> (auth.hasViewOrgs() || auth.hasOrgViewOrg(m)))
         .map(m -> convertOrganizationModelToOrganization(m));
   }

--- a/src/main/java/io/phasetwo/service/resource/OrganizationsResource.java
+++ b/src/main/java/io/phasetwo/service/resource/OrganizationsResource.java
@@ -77,15 +77,16 @@ public class OrganizationsResource extends OrganizationAdminResource {
     firstResult = firstResult != null ? firstResult : 0;
     maxResults = maxResults != null ? maxResults : Constants.DEFAULT_MAX_RESULTS;
 
-    if (search != null && searchQuery != null) {
-      throw new BadRequestException("Only one of search or q can be provided.");
-    }
+    log.debugf(
+        "listOrgs %s %s %s %d %d", realm.getName(), search, searchQuery, firstResult, maxResults);
 
     if (searchQuery != null) {
-      log.debugf("listOrgs %s %s %d %d", realm.getName(), searchQuery, firstResult, maxResults);
-
       Map<String, String> searchAttributes =
           searchQuery == null ? Collections.emptyMap() : SearchQueryUtils.getFields(searchQuery);
+
+      if (search != null) {
+        searchAttributes.put("name", search.trim());
+      }
 
       return orgs.searchForOrganizationByAttributesStream(
               realm, searchAttributes, firstResult, maxResults)
@@ -93,7 +94,6 @@ public class OrganizationsResource extends OrganizationAdminResource {
           .map(m -> convertOrganizationModelToOrganization(m));
     }
 
-    log.debugf("listOrgs %s %s %d %d", realm.getName(), search, firstResult, maxResults);
     return orgs.searchForOrganizationByNameStream(realm, search, firstResult, maxResults)
         .filter(m -> (auth.hasViewOrgs() || auth.hasOrgViewOrg(m)))
         .map(m -> convertOrganizationModelToOrganization(m));

--- a/src/test/java/io/phasetwo/service/resource/OrganizationResourceTest.java
+++ b/src/test/java/io/phasetwo/service/resource/OrganizationResourceTest.java
@@ -93,11 +93,12 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     PhaseTwo client = phaseTwo();
     OrganizationsResource orgsResource = client.organizations(REALM);
     //create some orgs
-    List<String> ids = new ArrayList<String>(); 
+    List<String> ids = new ArrayList<String>();
     ids.add(orgsResource.create(new OrganizationRepresentation().name("example").domains(List.of("example.com"))));
     ids.add(orgsResource.create(new OrganizationRepresentation().name("foo").domains(List.of("foo.com"))));
     ids.add(orgsResource.create(new OrganizationRepresentation().name("foobar").domains(List.of("foobar.com"))));
     ids.add(orgsResource.create(new OrganizationRepresentation().name("bar").domains(List.of("bar.com"))));
+    ids.add(orgsResource.create(new OrganizationRepresentation().name("baz").domains(List.of("baz.com")).attributes(Map.of("foo", List.of("bar")))));
 
     List<OrganizationRepresentation> orgs = orgsResource.get(Optional.of("foo"), Optional.empty(), Optional.empty());
     assertThat(orgs, notNullValue());
@@ -117,7 +118,18 @@ public class OrganizationResourceTest extends AbstractResourceTest {
 
     orgs = orgsResource.get(Optional.of("a"), Optional.empty(), Optional.empty());
     assertThat(orgs, notNullValue());
-    assertThat(orgs, hasSize(3));
+    assertThat(orgs, hasSize(4));
+
+    //orgs attribute search
+    try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+      String url = server.getAuthUrl() + "/realms/master/orgs?q=foo:bar";
+      SimpleHttp.Response response = SimpleHttp.doGet(url, httpClient)
+          .auth(server.client().tokenManager().getAccessTokenString())
+          .asResponse();
+      assertThat(response.getStatus(), is(200));
+      List<OrganizationRepresentation> res = response.asJson(List.class);
+      assertThat(res.size(), is(1));
+    }
 
     //orgs count
     try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
@@ -127,14 +139,14 @@ public class OrganizationResourceTest extends AbstractResourceTest {
           .asResponse();
       assertThat(response.getStatus(), is(200));
       Long cnt = response.asJson(Long.class);
-      assertThat(cnt, is(4l));
+      assertThat(cnt, is(5l));
     }
 
     for (String id : ids) {
       orgsResource.organization(id).delete();
     }
   }
-  
+
   @Test
   public void testGetDomains() {
     PhaseTwo client = phaseTwo();
@@ -160,7 +172,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     domains = domainsResource.get();
     assertThat(domains, notNullValue());
     assertThat(domains, hasSize(2));
-    
+
     for (OrganizationDomainRepresentation d : domains) {
       assertThat(d.getDomainName(), oneOf("foo.com", "bar.net"));
       assertThat(d.getVerified(), is(false));
@@ -266,8 +278,6 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     assertThat(organizations, empty());
   }
 
-
-
   @Test
   public void testMembershipsCount() {
     Keycloak keycloak = server.client();
@@ -302,7 +312,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
       return 0l;
     }
   }
-  
+
   @Test
   public void testAddGetDeleteMemberships() {
     Keycloak keycloak = server.client();
@@ -585,7 +595,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     // create idp
     String alias1 = idpResource.create(idp);;
     assertThat(alias1, notNullValue());
-    
+
     // get idps
     List<IdentityProviderRepresentation> idps = idpResource.get();
     assertThat(idps, notNullValue());


### PR DESCRIPTION
### TL;DR
Following on from discussion in #88, this adds the ability to search for organizations based on their key=value attribute pairs, using a new `q` query paramter on the search resource, i.e `GET /:realm/orgs?q=foo:bar`.

### Notes:
- The `q` and `key:value` search param follows convention in Keycloak core, such as the [User search API](https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java#L231-L338).
- ~~The API will now return a `400 Bad request` if both a `search` and `q` parameter are provided.~~ 
- I haven't included the ability to query other organization fields other than attirbutes (as there aren't many and my personal need was for attributes). However, it should be an easy refactor in the future.
- As this addition isn't yet avalable via the phase-two java client, I had to add a raw HTTP test, I hope this is ok?
- As this is a new optional query param, I consider this a non-breaking change to the API, but let me know if you disagree. 

---

Closes #88 