### PR TITLE
Update database changesets to support MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ The maven build uses the shade plugin to package a fat-jar with all dependencies
 
 During the first run, some initial migrations steps will occur:
 
-- Database migrations will be run to add the tables for use by the JPA entities. These have been tested with SQL Server, MySQL, H2, and Postgres. Other database types may fail.
+- Database migrations will be run to add the tables for use by the JPA entities. These have been tested with SQL Server,
+  MySQL, MariaDB, H2, and Postgres. Other database types may fail.
 - Initial `realm-management` client roles (`view-organizations` and `manage-organizations`) will be be added to each realm.
 
 ### Admin UI

--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-20200611-1.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-20200611-1.xml
@@ -3,7 +3,10 @@
     <changeSet author="garth" id="20200611-1-0">
         <preConditions onFail="MARK_RAN">
             <not>
-                <dbms type="mysql"/>
+                <or>
+                    <dbms type="mysql"/>
+                    <dbms type="mariadb"/>
+                </or>
             </not>
         </preConditions>
         <renameColumn columnDataType="VARCHAR(36)"
@@ -12,10 +15,13 @@
             tableName="INVITATION_TEAM"/>
     </changeSet>
 
-    <!-- mysql specific -->
+    <!-- mysql/mariadb specific -->
     <changeSet author="garth" id="20200611-1-">
         <preConditions onFail="MARK_RAN">
-            <dbms type="mysql"/>
+            <or>
+                <dbms type="mysql"/>
+                <dbms type="mariadb"/>
+            </or>
         </preConditions>
         <dropForeignKeyConstraint baseTableName="INVITATION_TEAM" constraintName="FK_lhea5u4vqt3n9694kq7hyl5at"/>
         <dropUniqueConstraint tableName="INVITATION_TEAM" constraintName="UK_lhea5u4vqt3n9694kq7hyl5at"/>

--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-20211208.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-20211208.xml
@@ -5,7 +5,10 @@
     <validCheckSum>8:7776fbcd4917bc8d6110eedb5a638479</validCheckSum>
     <preConditions onFail="MARK_RAN">
         <not>
+          <or>
             <dbms type="mysql"/>
+            <dbms type="mariadb"/>
+          </or>
         </not>
     </preConditions>
     <dropUniqueConstraint
@@ -14,10 +17,13 @@
             uniqueColumns="ORGANIZATION_ID, USER_ID, ROLE_ID"/>
   </changeSet>
 
-  <!-- mysql specific -->
+  <!-- mysql/mariadb specific -->
   <changeSet author="garth" id="drop-column-user-org-role-org-0-1">
     <preConditions onFail="MARK_RAN">
-      <dbms type="mysql"/>
+      <or>
+        <dbms type="mysql"/>
+        <dbms type="mariadb"/>
+      </or>
     </preConditions>
     <dropForeignKeyConstraint baseTableName="USER_ORGANIZATION_ROLE_MAPPING" constraintName="FK_HGF6S4UUNYWDKP4244YTNGBAD"/>
     <dropUniqueConstraint

--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-20220221.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-20220221.xml
@@ -4,16 +4,22 @@
   <changeSet author="garth" id="org-name-unique-constraint-drop">
     <preConditions onFail="MARK_RAN">
         <not>
+          <or>
             <dbms type="mysql"/>
+            <dbms type="mariadb"/>
+          </or>
         </not>
     </preConditions>
     <dropUniqueConstraint constraintName="UK_19A0TR48O23ALOR84GB8E3GC2" tableName="ORGANIZATION_ATTRIBUTE"/>
   </changeSet>
 
-  <!-- mysql specific -->
+  <!-- mysql/mariadb specific -->
   <changeSet author="garth" id="org-name-unique-constraint-drop-1">
     <preConditions onFail="MARK_RAN">
+      <or>
         <dbms type="mysql"/>
+        <dbms type="mariadb"/>
+      </or>
     </preConditions>
     <dropForeignKeyConstraint baseTableName="ORGANIZATION_ATTRIBUTE" constraintName="FK_519erdjtqivq189pm1ouanaix"/>
     <dropUniqueConstraint constraintName="UK_19A0TR48O23ALOR84GB8E3GC2" tableName="ORGANIZATION_ATTRIBUTE"/>


### PR DESCRIPTION
Fixes https://github.com/p2-inc/keycloak-orgs/issues/111.

Adds mariadb to the DBMS types for which to run "mysql-style" migrations.

ETA: Tested by hotfixing `phasetwo-keycloak:21.1.2.1688664025` with the .jar built from this branch against MariaDB-10.6.9. Migrations complete.