### PR TITLE
Add index to ORGANIZATION_ATTRIBUTE on ORGANIZATION_ID column

### DIFF
--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-20231030.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-20231030.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet author="phamann" id="add-organization-attribute-index" >
+        <createIndex indexName="IDX_ORGANIZATION_ATTRIBUTE" tableName="ORGANIZATION_ATTRIBUTE">
+            <column name="ORGANIZATION_ID" type="VARCHAR(36)"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
### What?
Adds a database index to the `ORGANIZATION_ATTRIBUTE` table on the `ORGANIZATION_ID` column, to improve query performance when searching orgs by attribute such as `/realms/:realm/orgs?q=foo=bar`. 

### Why?
We've noticed slow queries to the search endpoint when querying a database with both a lot of orgs and with each org having a lot of attributes. 

Example slow queries:
```
select a1_0.ORGANIZATION_ID,a1_0.ID,a1_0.NAME,a1_0.VALUE from ORGANIZATION_ATTRIBUTE a1_0 where a1_0.ORGANIZATION_ID=?
```

```
SELECT `o1_0` . `ID` , `o1_0` . `CREATED_BY_USER_ID` , `o1_0` . `DISPLAY_NAME` , `o1_0` . `NAME` , `o1_0` . `REALM_ID` , `o1_0` . `URL` FROM ORGANIZATION `o1_0` LEFT JOIN `ORGANIZATION_ATTRIBUTE` `a1_0` ON `o1_0` . `ID` = `a1_0` . `ORGANIZATION_ID` WHERE `lower` ( `a1_0` . `NAME` ) = ? AND `lower` ( `a1_0` . `VALUE` ) = ? AND `o1_0` . `REALM_ID` = ? ORDER BY `o1_0` . `NAME` LIMIT ?
```