### PR TITLE
Add 'organization/role' flattened claim array mapper

### DIFF
--- a/src/main/java/io/phasetwo/service/protocol/oidc/mappers/AbstractOrganizationMapper.java
+++ b/src/main/java/io/phasetwo/service/protocol/oidc/mappers/AbstractOrganizationMapper.java
@@ -1,7 +1,6 @@
 package io.phasetwo.service.protocol.oidc.mappers;
 
 import java.util.List;
-import java.util.Map;
 import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
@@ -66,7 +65,7 @@ public abstract class AbstractOrganizationMapper extends AbstractOIDCProtocolMap
     return helpText;
   }
 
-  protected abstract Map<String, Object> getOrganizationClaim(
+  protected abstract Object getOrganizationClaim(
       KeycloakSession session, RealmModel realm, UserModel user);
 
   @Override
@@ -91,7 +90,6 @@ public abstract class AbstractOrganizationMapper extends AbstractOIDCProtocolMap
       KeycloakSession keycloakSession,
       ClientSessionContext clientSessionCtx) {
     log.debugf("adding org claim to accessToken for %s", userSession.getUser().getUsername());
-    UserModel user = userSession.getUser();
     Object claim =
         getOrganizationClaim(keycloakSession, userSession.getRealm(), userSession.getUser());
     if (claim == null) return;

--- a/src/main/java/io/phasetwo/service/protocol/oidc/mappers/OrganizationRoleFlatMapper.java
+++ b/src/main/java/io/phasetwo/service/protocol/oidc/mappers/OrganizationRoleFlatMapper.java
@@ -1,0 +1,73 @@
+package io.phasetwo.service.protocol.oidc.mappers;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.Lists;
+import io.phasetwo.service.model.OrganizationProvider;
+import java.util.List;
+import lombok.extern.jbosslog.JBossLog;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.protocol.ProtocolMapper;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+@JBossLog
+@AutoService(ProtocolMapper.class)
+public class OrganizationRoleFlatMapper extends AbstractOrganizationMapper {
+
+    public static final String PROVIDER_ID = "oidc-organization-role-flattened-mapper";
+
+    public static List<ProviderConfigProperty> configProperties = Lists.newArrayList();
+
+    static {
+        configProperties = ProviderConfigurationBuilder.create()
+                .property()
+                .name(ProtocolMapperUtils.MULTIVALUED)
+                .type(ProviderConfigProperty.BOOLEAN_TYPE)
+                .label(ProtocolMapperUtils.MULTIVALUED_LABEL)
+                .helpText(ProtocolMapperUtils.MULTIVALUED_HELP_TEXT)
+                .defaultValue(true)
+                .add()
+                .build();
+        OIDCAttributeMapperHelper.addAttributeConfig(configProperties, OrganizationRoleFlatMapper.class);
+    }
+
+    public OrganizationRoleFlatMapper() {
+        super(
+                PROVIDER_ID,
+                "Organization Roles Flattened",
+                TOKEN_MAPPER_CATEGORY,
+                "Map organization roles in a token claim flattened.",
+                configProperties);
+    }
+
+    /*
+     * roles: [
+     * {organizationName}/{roleName}
+     * ]
+     * gets all the roles for each organization of which the user is a member
+     */
+    @Override
+    protected List<String> getOrganizationClaim(
+            KeycloakSession session, RealmModel realm, UserModel user) {
+        OrganizationProvider orgs = session.getProvider(OrganizationProvider.class);
+
+        List<String> claim = Lists.newArrayList();
+
+        orgs.getUserOrganizationsStream((realm), user)
+                .forEach(o -> {
+                    o.getRolesStream()
+                            .forEach(r -> {
+                                if (r.hasRole(user)) {
+                                    claim.add(String.format("%s/%s", o.getName(), r.getName()));
+                                }
+                            });
+                });
+
+        log.debugf("created user %s claim %s", user.getUsername(), claim);
+        return claim;
+    }
+}


### PR DESCRIPTION
Adds a new mapper which maps roles to a claim in '{organization}/{role}' format. I would love to map organization roles into the RBAC model of ArgoCD, which cant work tych mapped type of organization / role.

https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/keycloak/

Im not a java programmer, tried to do my best. Feedback and edits are welcome.