### PR TITLE
Fix precondition in organization attribute index database migration

### DIFF
--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-20231030.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-20231030.xml
@@ -6,7 +6,9 @@
 
   <changeSet author="phamann" id="add-organization-attribute-index" >
     <preConditions onFail="MARK_RAN">
-      <indexExists indexName="IDX_ORGANIZATION_ATTRIBUTE" />
+      <not>
+          <indexExists indexName="IDX_ORGANIZATION_ATTRIBUTE" />
+      </not>
     </preConditions>
     <createIndex indexName="IDX_ORGANIZATION_ATTRIBUTE" tableName="ORGANIZATION_ATTRIBUTE">
       <column name="ORGANIZATION_ID" type="VARCHAR(36)"/>


### PR DESCRIPTION
### TL;DR
Fixes a database migration `preCondition` that was introduced in https://github.com/p2-inc/keycloak-orgs/pull/145 - as the logic needs to be inverted. I.e. the pre condition needs to fail, not succeed. 

We've only finally got around to running the version of `keycloak-orgs` which introduced this change in our enviroments and this was causing a crashloop failure when deployed as we already had the index applied.