### PR TITLE
Update Active Organization Attribute for v24

### DIFF
--- a/docs/active-organization.md
+++ b/docs/active-organization.md
@@ -6,7 +6,7 @@
   * [Contents](#contents)
   * [Overview](#overview)
     * [Currently supported mode](#currently-supported-mode)
-      * [Important note (`ATTRIBUTE_MODE`)](#important-note-attribute_mode)
+      * [Important note (`ATTRIBUTE_MODE`) before v24.x+](#important-note-attribute_mode-before-v24x)
     * [Code extension](#code-extension)
   * [Endpoints](#endpoints)
     * [Switch Organization](#switch-organization)
@@ -15,7 +15,7 @@
     * [New mapper](#new-mapper)
     * [Configure the mapper](#configure-the-mapper)
   * [Standard Flow (Demo)](#standard-flow-demo)
-  * [Attack Scenario and Mitigation](#attack-scenario-and-mitigation)
+  * [Attack Scenario and Mitigation (before v24.x+)](#attack-scenario-and-mitigation-before-v24x)
     * [Case with user read only attributes](#case-with-user-read-only-attributes)
     * [Case with no user read only attributes](#case-with-no-user-read-only-attributes)
 <!-- TOC -->
@@ -28,7 +28,8 @@ This means that the active organization is kept in the user's attributes, he doe
 - If the user doesn't have an active organization attribute and belong to one or more organization, the first one is taken by default.  
 - Switching organization create a new session for the user (it return a new access token).
 
-#### Important note (`ATTRIBUTE_MODE`)
+#### Important note (`ATTRIBUTE_MODE`) before v24.x+
+**Starting of the version 24.x+, the org.ro.active is not visible and not editable by standard users.**
 Currently, the attribute key for active organization is not configurable and is by default `org.ro.active`.  
 It follows this format as it can be set as read-only with `--spi-user-profile-declarative-user-profile-read-only-attributes=org.ro.*` 
 of Keycloak which is **recommended**.  
@@ -208,7 +209,9 @@ Side note, if the user tries to get the active-organization without belonging to
 the `404 NOT FOUND` response will be returned.
 ![no-organization](assets/active-organization/flow/case-with-no-org.png)
 
-## Attack Scenario and Mitigation
+## Attack Scenario and Mitigation (before v24.x+)
+**Starting of the version 24.x+, the org.ro.active is not visible and not editable by standard users.**
+
 Now, let's assume the standard user is malicious and knows a little about Keycloak.  
 He may think that he could change organization by directly writing the `org.ro.active` attribute.
 

--- a/src/main/java/io/phasetwo/service/Orgs.java
+++ b/src/main/java/io/phasetwo/service/Orgs.java
@@ -9,4 +9,5 @@ public class Orgs {
       "_providerConfig.orgs.defaults.postBrokerFlow";
   public static final String ORG_DEFAULT_SYNC_MODE_KEY = "_providerConfig.orgs.defaults.syncMode";
   public static final String ACTIVE_ORGANIZATION = "org.ro.active";
+  public static final String KC_ORGS_SKIP_MIGRATION = System.getenv("KC_ORGS_SKIP_MIGRATION");
 }

--- a/src/main/java/io/phasetwo/service/resource/OrganizationResourceProviderFactory.java
+++ b/src/main/java/io/phasetwo/service/resource/OrganizationResourceProviderFactory.java
@@ -1,5 +1,6 @@
 package io.phasetwo.service.resource;
 
+import static io.phasetwo.service.Orgs.KC_ORGS_SKIP_MIGRATION;
 import static io.phasetwo.service.resource.OrganizationAdminAuth.DEFAULT_ORG_ROLES;
 import static io.phasetwo.service.resource.OrganizationAdminAuth.ROLE_CREATE_ORGANIZATION;
 import static io.phasetwo.service.resource.OrganizationAdminAuth.ROLE_MANAGE_ORGANIZATION;
@@ -61,7 +62,7 @@ public class OrganizationResourceProviderFactory implements RealmResourceProvide
             realmPostCreate((RealmModel.RealmPostCreateEvent) event);
           } else if (event instanceof PostMigrationEvent) {
             log.debug("PostMigrationEvent");
-            if (System.getenv("KC_ORGS_SKIP_MIGRATION") == null) {
+            if (KC_ORGS_SKIP_MIGRATION == null) {
               log.info("initializing organization roles following migration");
               KeycloakModelUtils.runJobInTransaction(factory, this::initRoles);
             }

--- a/src/main/java/io/phasetwo/service/resource/UserResourceProviderFactory.java
+++ b/src/main/java/io/phasetwo/service/resource/UserResourceProviderFactory.java
@@ -1,12 +1,27 @@
 package io.phasetwo.service.resource;
 
+import static io.phasetwo.service.Orgs.ACTIVE_ORGANIZATION;
+import static io.phasetwo.service.Orgs.KC_ORGS_SKIP_MIGRATION;
+
 import com.google.auto.service.AutoService;
+import java.util.HashSet;
+import java.util.List;
 import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.Config;
+import org.keycloak.component.ComponentValidationException;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.models.utils.PostMigrationEvent;
+import org.keycloak.provider.ProviderEvent;
+import org.keycloak.representations.userprofile.config.UPAttribute;
+import org.keycloak.representations.userprofile.config.UPAttributePermissions;
+import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.services.resource.RealmResourceProvider;
 import org.keycloak.services.resource.RealmResourceProviderFactory;
+import org.keycloak.userprofile.UserProfileProvider;
+import org.keycloak.userprofile.config.UPConfigUtils;
 
 @JBossLog
 @AutoService(RealmResourceProviderFactory.class)
@@ -24,7 +39,75 @@ public class UserResourceProviderFactory implements RealmResourceProviderFactory
   public void init(Config.Scope config) {}
 
   @Override
-  public void postInit(KeycloakSessionFactory factory) {}
+  public void postInit(KeycloakSessionFactory factory) {
+
+    log.debug("UserResourceProviderFactory::postInit");
+
+    factory.register(
+        (ProviderEvent event) -> {
+          if (event instanceof RealmModel.RealmPostCreateEvent) {
+            log.debug("RealmPostCreateEvent");
+            realmPostCreateInitUserProfile((RealmModel.RealmPostCreateEvent) event);
+          } else if (event instanceof PostMigrationEvent) {
+            log.debug("PostMigrationEvent");
+            if (KC_ORGS_SKIP_MIGRATION == null) {
+              log.info("initializing active organization user profile attribute following migration");
+              KeycloakModelUtils.runJobInTransaction(factory, this::postMigrationInitUserProfile);
+            }
+          }
+        }
+    );
+  }
+
+  private void realmPostCreateInitUserProfile(RealmModel.RealmPostCreateEvent event) {
+    log.debug("UserResourceProviderFactory::realmPostCreateInitUserProfile");
+    KeycloakSession session = event.getKeycloakSession();
+    // else session.getProvider throw realm is null
+    session.getContext().setRealm(event.getCreatedRealm());
+    initUserProfile(session);
+  }
+
+  private void postMigrationInitUserProfile(KeycloakSession session) {
+    log.debug("UserResourceProviderFactory::postMigrationInitUserProfile");
+    session
+        .realms()
+        .getRealmsStream()
+        .forEach(
+            realm -> {
+              session.getContext().setRealm(realm);
+              initUserProfile(session);
+            }
+        );
+  }
+
+  private void initUserProfile(KeycloakSession session) {
+    log.debug("UserResourceProviderFactory::initUserProfile");
+
+    UPConfig config = session.getProvider(UserProfileProvider.class).getConfiguration();
+    addActiveOrganizationAttribute(config);
+
+    UserProfileProvider t = session.getProvider(UserProfileProvider.class);
+    try {
+      t.setConfiguration(config);
+    } catch (ComponentValidationException e) {
+      //show validation result containing details about error
+      log.error(e.getMessage());
+    }
+  }
+
+  private void addActiveOrganizationAttribute(UPConfig config) {
+    if (config.getAttribute(ACTIVE_ORGANIZATION) != null) return;
+
+    UPAttribute activeOrgAttribute = new UPAttribute();
+    activeOrgAttribute.setName(ACTIVE_ORGANIZATION);
+    activeOrgAttribute.setDisplayName("Active organization ID");
+    UPAttributePermissions permissions = new UPAttributePermissions();
+    permissions.setEdit(new HashSet<>(List.of(UPConfigUtils.ROLE_ADMIN)));
+    permissions.setView(new HashSet<>(List.of(UPConfigUtils.ROLE_ADMIN)));
+    activeOrgAttribute.setPermissions(permissions);
+    activeOrgAttribute.setMultivalued(false);
+    config.getAttributes().add(activeOrgAttribute);
+  }
 
   @Override
   public void close() {}

--- a/src/main/java/io/phasetwo/service/util/ActiveOrganization.java
+++ b/src/main/java/io/phasetwo/service/util/ActiveOrganization.java
@@ -5,6 +5,7 @@ import static io.phasetwo.service.Orgs.ACTIVE_ORGANIZATION;
 import com.google.common.collect.Lists;
 import io.phasetwo.service.model.OrganizationModel;
 import io.phasetwo.service.model.OrganizationProvider;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -46,26 +47,15 @@ public class ActiveOrganization {
       activeOrganizationId = user.getFirstAttribute(ACTIVE_ORGANIZATION);
     }
 
-    // security measure
-    // verify that the user belong to the organization (in case he modified through account POST
-    // api)
-    // no issue if read-only user attributes is enabled with "org.ro.*"
-    // --spi-user-profile-declarative-user-profile-read-only-attributes=org.ro.*
+    // lazy removal of active org attribute when org is deleted
     if (organizationProvider
         .getUserOrganizationsStream(realm, user)
         .noneMatch(org -> org.getId().equals(activeOrganizationId))) {
       log.warnf("%s doesn't belong to this organization", user.getUsername());
-
-      // verify that the organization still exists
-      organization = organizationProvider.getOrganizationById(realm, activeOrganizationId);
-      if (organization == null) {
-        log.warnf("organization doesn't exists anymore.");
-        user.removeAttribute(ACTIVE_ORGANIZATION);
-        // TODO: This method has a side effect. In the future it should be removed and the code
-        // refactored
-        // Tests failed if the we had event here
-      }
-
+      user.setAttribute(ACTIVE_ORGANIZATION, new ArrayList<>());
+      // TODO: This method has a side effect. In the future it should be removed and the code
+      // refactored
+      // Tests failed if the we had event here
       return false;
     }
 

--- a/src/main/java/io/phasetwo/service/util/TokenManager.java
+++ b/src/main/java/io/phasetwo/service/util/TokenManager.java
@@ -38,7 +38,6 @@ public class TokenManager {
 
   public TokenManager(
       KeycloakSession session, AccessToken accessToken, RealmModel realm, UserModel user) {
-    this.session = session;
     this.accessToken = accessToken;
     this.realm = realm;
     this.targetClient =
@@ -47,6 +46,8 @@ public class TokenManager {
             .getClientByClientId(realm, accessToken.getIssuedFor());
     this.targetClientConfig = OIDCAdvancedConfigWrapper.fromClientModel(targetClient);
     this.user = user;
+    this.session = session;
+    this.session.getContext().setClient(targetClient);
   }
 
   /**


### PR DESCRIPTION
Fixes for https://github.com/p2-inc/keycloak-orgs/issues/195

- Implement "Active Organization ID" attribute creation in UserProfile on migration or realm creation.
- Add some fixes related to v24 changes.
- Update tests accordingly to adapt to the new logic of UserProfile
- Update the documentation accordingly