### PR TITLE
multiple user's name as query parameter

### DIFF
--- a/src/main/java/io/phasetwo/service/model/jpa/OrganizationAdapter.java
+++ b/src/main/java/io/phasetwo/service/model/jpa/OrganizationAdapter.java
@@ -165,15 +165,23 @@ public class OrganizationAdapter implements OrganizationModel, JpaModel<Organiza
   @Override
   public Stream<UserModel> searchForMembersStream(
       String search, Integer firstResult, Integer maxResults) {
+    String[] searchTerms = Strings.isNullOrEmpty(search) ? null : search.split(",");
     // TODO this could be optimized for large member lists with a query
     return getMembersStream()
         .filter(
             (m) -> {
-              if (Strings.isNullOrEmpty(search)) return true;
-              return (m.getEmail() != null && m.getEmail().toLowerCase().contains(search))
-                  || (m.getUsername() != null && m.getUsername().toLowerCase().contains(search))
-                  || (m.getFirstName() != null && m.getFirstName().toLowerCase().contains(search))
-                  || (m.getLastName() != null && m.getLastName().toLowerCase().contains(search));
+              if (searchTerms == null) return true;
+              for (String searchTerm : searchTerms) {
+                String term = searchTerm.trim().toLowerCase();
+                if (term.isEmpty()) continue;
+                if ((m.getEmail() != null && m.getEmail().toLowerCase().contains(term))
+                        || (m.getUsername() != null && m.getUsername().toLowerCase().contains(term))
+                        || (m.getFirstName() != null && m.getFirstName().toLowerCase().contains(term))
+                        || (m.getLastName() != null && m.getLastName().toLowerCase().contains(term))){
+                  return true;
+                }
+              }
+              return false;
             })
         .skip(firstResult)
         .limit(maxResults);


### PR DESCRIPTION
I changed some codes of `searchForMembersStream()` so that it can search the members of organization with multiple user's name as query parameter. This is related to this issue [132](https://github.com/p2-inc/keycloak-orgs/issues/132)

With this function, it is possible to search users of organization with multiple names in one api like below.
`GET /realms/{realm}/orgs/{orgId}/members?search=jack,jill`
`GET /realms/{realm}/orgs/{orgId}/members?search=, jack, john, mary`

I used the comma as delimiter as shown in the issue.