### PR TITLE
fix issue with duplicate grant flow being created on each startup

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/ActiveOrganizationAuthenticatorFactory.java
+++ b/src/main/java/io/phasetwo/service/auth/ActiveOrganizationAuthenticatorFactory.java
@@ -151,7 +151,14 @@ public class ActiveOrganizationAuthenticatorFactory implements AuthenticatorFact
   }
 
   private void createOrgDirectGrantFlow(RealmModel realm) {
-    AuthenticationFlowModel grant = new AuthenticationFlowModel();
+    AuthenticationFlowModel grant = realm.getFlowByAlias(ORG_DIRECT_GRANT_AUTH_FLOW_ALIAS);
+    if (grant != null) {
+      log.infof("%s flow exists. Skipping.", ORG_DIRECT_GRANT_AUTH_FLOW_ALIAS);
+      return;
+    }
+
+    log.infof("creating built-in auth flow for %s", ORG_DIRECT_GRANT_AUTH_FLOW_ALIAS);
+    grant = new AuthenticationFlowModel();
     grant.setAlias(ORG_DIRECT_GRANT_AUTH_FLOW_ALIAS);
     grant.setDescription("Direct grant flow with select organization step.");
     grant.setProviderId(AuthenticationFlow.BASIC_FLOW);


### PR DESCRIPTION
While doing some local development, I noticed that a new Org Direct Grant authentication flow was being duplicated each time I booted up the container. I noticed that the Org Browser flow had an existing check, but not the Org Direct Grant flow. This PR adds that same check for the second flow as well.

<img width="1154" alt="Screenshot 2024-05-09 at 10 27 54 PM" src="https://github.com/p2-inc/keycloak-orgs/assets/22361766/55cc6977-ec73-467e-bac5-1e3260e84247">