### PR TITLE
adds user_id index to organization members table

### DIFF
--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-20240610.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-20240610.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <changeSet author="richardalberto" id="add-organization-member-user-index" >
+    <preConditions onFail="MARK_RAN">
+      <not>
+          <indexExists indexName="IDX_USER_ID" />
+      </not>
+    </preConditions>
+    <createIndex indexName="IDX_USER_ID" tableName="ORGANIZATION_MEMBER">
+      <column name="USER_ID" type="VARCHAR(255)"/>
+    </createIndex>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-master.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-master.xml
@@ -22,5 +22,6 @@
   <include file="META-INF/jpa-changelog-phasetwo-20240123.xml"/>
   <include file="META-INF/jpa-changelog-phasetwo-20240229.xml"/>
   <include file="META-INF/jpa-changelog-phasetwo-20240308.xml"/>
+  <include file="META-INF/jpa-changelog-phasetwo-20240610.xml"/>
   
 </databaseChangeLog>


### PR DESCRIPTION
As the number of organization members increases we've noticed the get member routines could benefit from an index. 

Example Query: 
```
SELECT `ome1_0` . `ID` , `ome1_0` . `CREATED_AT` , `ome1_0` . `ORGANIZATION_ID` , `ome1_0` . `USER_ID` FROM `ORGANIZATION_MEMBER` `ome1_0` WHERE `ome1_0` . `USER_ID` = ?
```