### PR TITLE
Remove DomainExtractor email verification check to fix unverified bug

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/idp/DomainExtractor.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/DomainExtractor.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 final class DomainExtractor {
 
     private static final Logger LOG = Logger.getLogger(DomainExtractor.class);
-    private static final String EMAIL_ATTRIBUTE = "email";
 
     private final HomeIdpDiscoveryConfig config;
 
@@ -25,10 +24,6 @@ final class DomainExtractor {
         String userAttribute = user.getFirstAttribute(config.userAttribute());
         if (userAttribute == null) {
             LOG.warnf("Could not find user attribute '%s' for user '%s'", config.userAttribute(), user.getId());
-            return Optional.empty();
-        }
-        if (EMAIL_ATTRIBUTE.equalsIgnoreCase(config.userAttribute()) && !user.isEmailVerified()) {
-            LOG.warnf("Email address of user '%s' is not verified", user.getId());
             return Optional.empty();
         }
         return extractFrom(userAttribute);


### PR DESCRIPTION
This mirrors the following PR in sventorben/keycloak-home-idp-discovery: https://github.com/sventorben/keycloak-home-idp-discovery/pull/248

This check is already performed in HomeIDPDiscoverer after extraction, so it's unnecessary:
```java
        if (config.requireVerifiedEmail()
            && "email".equalsIgnoreCase(config.userAttribute())
            && !user.isEmailVerified()) {
            LOG.infof("Email of user %s not verified. Skipping discovery of linked IdPs", user.getId());
            return homeIdps;
        }
```

Additionally, this means that the HomeIdpDiscoverer works improperly with unverified emails when requireVerifiedEmail=false:
1. At first login the user doesn't exist, so the email is unverified. Verification is skipped, the user goes through the auth flow as intended, and is now logged in.
2. The user logs out.
3. At second login, the user does exist, but the email is unverified. This check runs, even though unverified emails are supposed to be allowed in HomeIdpDiscoverer, and the login fails with the message: "Unexpected error when handling authentication request to identity provider."

This PR fixes this issue.