### PR TITLE
Add default organization role "delete-organization"

### DIFF
--- a/src/main/java/io/phasetwo/service/resource/OrganizationAdminAuth.java
+++ b/src/main/java/io/phasetwo/service/resource/OrganizationAdminAuth.java
@@ -144,6 +144,7 @@ public class OrganizationAdminAuth extends AdminAuth {
   //
 
   public static final String ORG_ROLE_VIEW_ORGANIZATION = "view-organization";
+  public static final String ORG_ROLE_DELETE_ORGANIZATION = "delete-organization";
   public static final String ORG_ROLE_MANAGE_ORGANIZATION = "manage-organization";
   public static final String ORG_ROLE_VIEW_MEMBERS = "view-members";
   public static final String ORG_ROLE_MANAGE_MEMBERS = "manage-members";
@@ -155,6 +156,7 @@ public class OrganizationAdminAuth extends AdminAuth {
   public static final String ORG_ROLE_MANAGE_IDENTITY_PROVIDERS = "manage-identity-providers";
 
   public static final String ORG_ROLE_VIEW_ORGANIZATION_DESC = "View this organization";
+  public static final String ORG_ROLE_DELETE_ORGANIZATION_DESC = "Delete this organization";
   public static final String ORG_ROLE_MANAGE_ORGANIZATION_DESC = "Manage this organization";
   public static final String ORG_ROLE_VIEW_MEMBERS_DESC = "View members of this organization";
   public static final String ORG_ROLE_MANAGE_MEMBERS_DESC =
@@ -173,6 +175,7 @@ public class OrganizationAdminAuth extends AdminAuth {
 
   public static final String[] DEFAULT_ORG_ROLES = {
     ORG_ROLE_VIEW_ORGANIZATION,
+    ORG_ROLE_DELETE_ORGANIZATION,
     ORG_ROLE_MANAGE_ORGANIZATION,
     ORG_ROLE_VIEW_MEMBERS,
     ORG_ROLE_MANAGE_MEMBERS,
@@ -187,6 +190,7 @@ public class OrganizationAdminAuth extends AdminAuth {
   public static final Map<String, String> DEFAULT_ORG_ROLES_DESC =
       new ImmutableMap.Builder<String, String>()
           .put(ORG_ROLE_VIEW_ORGANIZATION, ORG_ROLE_VIEW_ORGANIZATION_DESC)
+          .put(ORG_ROLE_DELETE_ORGANIZATION, ORG_ROLE_DELETE_ORGANIZATION_DESC)
           .put(ORG_ROLE_MANAGE_ORGANIZATION, ORG_ROLE_MANAGE_ORGANIZATION_DESC)
           .put(ORG_ROLE_VIEW_MEMBERS, ORG_ROLE_VIEW_MEMBERS_DESC)
           .put(ORG_ROLE_MANAGE_MEMBERS, ORG_ROLE_MANAGE_MEMBERS_DESC)
@@ -205,6 +209,15 @@ public class OrganizationAdminAuth extends AdminAuth {
    */
   boolean hasOrgViewOrg(OrganizationModel org) {
     return hasOrgRole(org, ORG_ROLE_VIEW_ORGANIZATION) || org.hasMembership(getUser());
+  }
+
+  /**
+   * @param org The selected organization
+   * @return true if the logged-in user has the delete-organization permission *IN* the specified 
+   *     org
+   */
+  boolean hasOrgDeleteOrg(OrganizationModel org) {
+    return hasOrgRole(org, ORG_ROLE_DELETE_ORGANIZATION);
   }
 
   /**

--- a/src/main/java/io/phasetwo/service/resource/OrganizationResource.java
+++ b/src/main/java/io/phasetwo/service/resource/OrganizationResource.java
@@ -107,17 +107,20 @@ public class OrganizationResource extends OrganizationAdminResource {
   public Response deleteOrg() {
     log.debugf("Delete org for %s %s", realm.getName(), orgId);
 
-    auth.requireManageOrgs();
-
-    if (orgs.removeOrganization(realm, orgId)) {
-      adminEvent
-          .resource(ORGANIZATION.name())
-          .operation(OperationType.DELETE)
-          .resourcePath(session.getContext().getUri())
-          .representation(orgId)
-          .success();
+    if (auth.hasManageOrgs() || auth.hasOrgDeleteOrg(organization)) {
+      if (orgs.removeOrganization(realm, orgId)) {
+        adminEvent
+            .resource(ORGANIZATION.name())
+            .operation(OperationType.DELETE)
+            .resourcePath(session.getContext().getUri())
+            .representation(orgId)
+            .success();
+      }
+      return Response.status(204).build();
+    } else {
+      throw new NotAuthorizedException(
+          String.format("Insufficient permission to delete %s", organization.getId()));
     }
-    return Response.status(204).build();
   }
 
   @PUT

--- a/src/test/resources/orgs/org-import-test.json
+++ b/src/test/resources/orgs/org-import-test.json
@@ -15,6 +15,9 @@
           "name": "view-organization"
         },
         {
+          "name": "delete-organization"
+        },
+        {
           "name": "manage-organization"
         },
         {
@@ -62,6 +65,9 @@
       "roles": [
         {
           "name": "view-organization"
+        },
+        {
+          "name": "delete-organization"
         },
         {
           "name": "manage-organization"


### PR DESCRIPTION
**What?**
Allow for organization admins to delete their organization

**Why?**
In applications with low revenue per user a common requirement is for organization admins to be allowed to delete their own organization.

As discussed in issue #263:
> The original design was to allow only users with the realm-management role manage-organizations to be able to create and delete organizations. An additional create-organization role was added to allow create without the other permissions, but no other role exists to delete organizations.

**How?**
- Added default organization role "delete-organization"
- Updated delete organization endpoint to not only check for the realm "manage-organization" role but also for the organization role "delete-organization"

**To discuss**
 In issue #263 there is no mention of the existing **organization** role named "manage-organization" which allows updating the organization (and generating portal link). Is the preference for a separate "delete-organization" role over expanding the scope of the "manage-organization" role so that we do not "expose" existing user/customers? Please note that the [current documentation](https://phasetwo.io/docs/organizations/roles/) states that the **organization** role "manage-organization" should allow deletes of the organization even though it does not at this point in time. Personally I feel like expanding the scope of "manage-organization" would be the better solution, especially since it does not match the documentation now.
