### PR TITLE
feat: allow invitation-required action to be initiated by the application

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/invitation/InvitationRequiredAction.java
+++ b/src/main/java/io/phasetwo/service/auth/invitation/InvitationRequiredAction.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.jbosslog.JBossLog;
+import org.keycloak.authentication.InitiatedActionSupport;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.events.EventBuilder;
@@ -23,6 +24,11 @@ import org.keycloak.models.UserModel;
 public class InvitationRequiredAction implements RequiredActionProvider {
 
   public InvitationRequiredAction() {}
+
+  @Override
+  public InitiatedActionSupport initiatedActionSupport() {
+    return InitiatedActionSupport.SUPPORTED;
+  }
 
   @Override
   public void evaluateTriggers(RequiredActionContext context) {


### PR DESCRIPTION
Hey everyone. 

We're eyeing to use keycloak orgs to replace our homegrown multi-tenant setup. One of the blockers we hit is that users will not see the invitation screen if they click the email link if they are already signed in.

We're solving this with a custom redirect_uri on invitations, and want to trigger the invitation-required action screen manually. To do this we implemented `initiatedActionSupport` on the action SPI. 

More information on app-initiated actions here: https://github.com/keycloak/keycloak-community/blob/main/design/application-initiated-actions.md

It's been working great on our end, let me know what you all think. Would love to get this upstream :)