### PR TITLE
Changed ORGANIZATION_ATTRIBUTE.VALUE back to nvarchar for mssql

### DIFF
--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-20250512.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-20250512.xml
@@ -1,0 +1,15 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="QuadmanSWE" id="org-attr-nvarchar-mssql">
+        <preConditions onFail="MARK_RAN">
+            <dbms type="mssql"/>
+        </preConditions>
+        <modifyDataType
+                tableName="ORGANIZATION_ATTRIBUTE"
+                columnName="VALUE"
+                newDataType="NVARCHAR(4000)" />
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-master.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-master.xml
@@ -24,5 +24,5 @@
   <include file="META-INF/jpa-changelog-phasetwo-20240308.xml"/>
   <include file="META-INF/jpa-changelog-phasetwo-20240610.xml"/>
   <include file="META-INF/jpa-changelog-phasetwo-20240611.xml"/>
-
+  <include file="META-INF/jpa-changelog-phasetwo-20250512.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Originally this column was created as nvarchar(255). It was then changed for every engine to varchar(255). But this causes issues for mssql specifically. This PR will fix #343 

relevant changes for this column:
https://github.com/p2-inc/keycloak-orgs/blob/90019714ade0ea2a7498d4c9c4dfb60abbdc6269/src/main/resources/META-INF/jpa-changelog-phasetwo-20200220.xml#L35C1-L42C23

https://github.com/p2-inc/keycloak-orgs/blob/90019714ade0ea2a7498d4c9c4dfb60abbdc6269/src/main/resources/META-INF/jpa-changelog-phasetwo-20240229.xml#L13C1-L20C15

This is my first contribution to phase2, and I have not worked with java or liquibase in a long time. So I haven't been able to run any tests for this script.

@xgp please review.