### PR TITLE
feat: added ability to import organization members based on user id

### DIFF
--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -260,6 +260,10 @@ If the `skipMissingMember` is set to `true`:
     {
       "username": "test2",
       "enabled": true
+    },
+    {
+      "id": "28092759-818c-4bb7-b83e-bded01a4227e",
+      "enabled": true
     }
     .......
   ],
@@ -296,8 +300,10 @@ If the `skipMissingMember` is set to `true`:
 
 | Member attribute | Required |
 |------------------|----------|
-| `username`       | `true`   |
-| `roles`          | `false`  |
+| `id`             | `true` if `username` is not provided * |
+| `username`       | `true` if `id` is not provided *       |
+| `roles`          | `false`                                |
+\* one of the two should be provided, providing both will result in an error
 
 ### Invitations import/export schema
 

--- a/src/main/java/io/phasetwo/service/importexport/KeycloakOrgsExportConverter.java
+++ b/src/main/java/io/phasetwo/service/importexport/KeycloakOrgsExportConverter.java
@@ -57,7 +57,7 @@ public final class KeycloakOrgsExportConverter {
                             .map(OrganizationRoleModel::getName)
                             .toList();
 
-                    return new UserRolesRepresentation(userModel.getUsername(), userRoles);
+                    return new UserRolesRepresentation(null, userModel.getUsername(), userRoles);
                   })
               .toList();
       organizationRepresentation.setMembers(members);

--- a/src/main/java/io/phasetwo/service/importexport/representation/UserRolesRepresentation.java
+++ b/src/main/java/io/phasetwo/service/importexport/representation/UserRolesRepresentation.java
@@ -19,6 +19,9 @@ import lombok.ToString;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UserRolesRepresentation {
 
+  @JsonProperty("id")
+  private String id;
+
   @JsonProperty("username")
   private String username;
 

--- a/src/test/resources/orgs/membership-test/org-member-import-missing-user-test.json
+++ b/src/test/resources/orgs/membership-test/org-member-import-missing-user-test.json
@@ -16,8 +16,11 @@
         },
         {
           "username": "test2",
-          "roles": [
-          ]
+          "roles": []
+        },
+        {
+          "id": "non-existing-should-not-fail-because-skip-missing-members",
+          "roles": []
         }
       ],
       "invitations": []

--- a/src/test/resources/orgs/membership-test/org-members-import-test-realm.json
+++ b/src/test/resources/orgs/membership-test/org-members-import-test-realm.json
@@ -7,6 +7,7 @@
       "enabled": true
     },
     {
+      "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
       "username": "test2",
       "enabled": true
     },

--- a/src/test/resources/orgs/membership-test/org-members-import-test.json
+++ b/src/test/resources/orgs/membership-test/org-members-import-test.json
@@ -16,7 +16,11 @@
         },
         {
           "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-          "roles": ["test_role1", "view-members", "manage-members"]
+          "roles": [
+            "test_role1",
+            "view-members",
+            "manage-members"
+          ]
         }
       ],
       "invitations": []

--- a/src/test/resources/orgs/membership-test/org-members-import-test.json
+++ b/src/test/resources/orgs/membership-test/org-members-import-test.json
@@ -15,12 +15,8 @@
           "roles": []
         },
         {
-          "username": "test2",
-          "roles": [
-            "test_role1",
-            "view-members",
-            "manage-members"
-          ]
+          "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+          "roles": ["test_role1", "view-members", "manage-members"]
         }
       ],
       "invitations": []


### PR DESCRIPTION
This PR adds support for importing organization members based on their Keycloak user ID. We’re migrating from a custom solution outside of Keycloak to keycloak-orgs, and currently only have Keycloak user IDs in that system (no usernames). So we need a way to import members using those user IDs.

The adjustments I made make sure either a `username` or `id` should be provided. Providing both with result in an error, to be explicit instead of implicitly using one over the other.