### PR TITLE
Fix session not found when webhook initiated

### DIFF
--- a/src/main/java/io/phasetwo/service/resource/OrganizationsResource.java
+++ b/src/main/java/io/phasetwo/service/resource/OrganizationsResource.java
@@ -114,10 +114,11 @@ public class OrganizationsResource extends OrganizationAdminResource {
 
     KeycloakModelUtils.runJobInTransaction(
         session.getKeycloakSessionFactory(),
+        session.getContext(),
         (session) -> {
           Invitations.memberFromInvitation(invitation, auth.getUser());
           invitation.getOrganization().revokeInvitation(invitationId);
-          EventBuilder event = new EventBuilder(realm, this.session, connection);
+          EventBuilder event = new EventBuilder(realm, session, connection);
 
           event
               .event(CUSTOM_REQUIRED_ACTION)


### PR DESCRIPTION
Fix Session not bound to a realm when issuing a ACCEPT INVITATION webhook event

Use global session, instead of transaction session