### PR TITLE
test: implement backend code coverage collection for Cypress E2E tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <lombok.version>1.18.42</lombok.version>
     <auto-service.version>1.1.1</auto-service.version>
     <ossrh.url>https://ossrh-staging-api.central.sonatype.com</ossrh.url>
+    <jacoco.version>0.8.14</jacoco.version>
   </properties>
 
   <scm>
@@ -56,6 +57,66 @@
       <properties>
         <include.cypress>true</include.cypress>
       </properties>
+      <build>
+        <plugins>
+          <!--   copy the jacoco agent to target build  -->
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-jacoco</id>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <phase>compile</phase>
+                <configuration>
+                  <includeArtifactIds>org.jacoco.agent</includeArtifactIds>
+                  <includeClassifiers>runtime</includeClassifiers>
+                  <outputDirectory>${project.build.directory}/jacoco-agent</outputDirectory>
+                  <stripVersion>true</stripVersion>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!--   set up jacoco plugin to generate report  -->
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${jacoco.version}</version>
+            <executions>
+              <execution>
+                <id>merge</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>merge</goal>
+                </goals>
+                <configuration>
+                  <fileSets>
+                    <fileSet>
+                      <directory>${project.build.directory}/jacoco-report/</directory>
+                      <includes>
+                        <include>*.exec</include>
+                      </includes>
+                    </fileSet>
+                  </fileSets>
+                  <destFile>${project.build.directory}/jacoco-report/jacoco-all.exec</destFile>
+                </configuration>
+              </execution>
+              <execution>
+                <id>report</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+                <configuration>
+                  <dataFile>${project.build.directory}/jacoco-report/jacoco-all.exec</dataFile>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 
@@ -362,6 +423,13 @@
       <groupId>io.github.wimdeblauwe</groupId>
       <artifactId>testcontainers-cypress</artifactId>
       <version>1.9.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <version>${jacoco.version}</version>
+      <classifier>runtime</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/io/phasetwo/web/AbstractCypressOrganizationTest.java
+++ b/src/test/java/io/phasetwo/web/AbstractCypressOrganizationTest.java
@@ -27,6 +27,8 @@ import io.restassured.specification.RequestSpecification;
 import jakarta.ws.rs.core.Response.Status;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -37,14 +39,12 @@ import org.hamcrest.Matchers;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DynamicContainer;
-import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.testcontainers.Testcontainers;
+import org.testcontainers.utility.MountableFile;
 
 @JBossLog
 @EnabledIfSystemProperty(named = "include.cypress", matches = "true")
@@ -94,17 +94,34 @@ public class AbstractCypressOrganizationTest {
           .withReuse(true)
           .withProviderClassesFrom("target/classes")
           .withProviderLibsFrom(getDeps())
-          .withEnv("JAVA_OPTS", "-XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m")
+          .withCopyFileToContainer(
+                  MountableFile.forHostPath("target/jacoco-agent/"),
+                  "/jacoco-agent"
+          )
+          .withEnv("JAVA_OPTS", "-XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -javaagent:/jacoco-agent/org.jacoco.agent-runtime.jar=destfile=/tmp/jacoco.exec")
           .withAccessToHost(true);
 
   protected static final int WEBHOOK_SERVER_PORT = 8083;
 
-  static {
-    container.start();
+  @AfterAll
+  public static void tearDown() throws IOException {
+    String containerId = container.getContainerId();
+    String containerShortId;
+    if (containerId.length() > 12) {
+      containerShortId = containerId.substring(0, 12);
+    } else {
+      containerShortId = containerId;
+    }
+    container.getDockerClient().stopContainerCmd(containerId).exec();
+    Files.createDirectories(Path.of("target", "jacoco-report"));
+    container.copyFileFromContainer("/tmp/jacoco.exec", "./target/jacoco-report/jacoco-%s.exec".formatted(containerShortId));
+    container.stop();
   }
 
   @BeforeAll
   public static void beforeAll() {
+    container.start();
+
     Testcontainers.exposeHostPorts(WEBHOOK_SERVER_PORT);
     resteasyClient =
         new ResteasyClientBuilderImpl()


### PR DESCRIPTION
Integrate JaCoCo into the Cypress test lifecycle to measure backend code coverage during integration testing.

Closes #408