### PR TITLE
Adding more tests for the `bypassLoginPage` option

### DIFF
--- a/src/test/e2e/cypress/e2e/home-idp-organization/bypass-login-enabled.cy.ts
+++ b/src/test/e2e/cypress/e2e/home-idp-organization/bypass-login-enabled.cy.ts
@@ -2,9 +2,60 @@ import { loginUriSelectAccount, tokenUri, testRealmLoginUri } from "../../fixtur
 import { user1, user2, user3, idpUser } from "../../fixtures/users";
 import { getRealmOrganizations, org1Name, org2Name } from "../../utils/organizations";
 
-describe('user login via home idp provider when bypassLogin is enabled', () => {
-   it('providing login_hint should automatically redirect the user to the upstream idp', () => {
+describe('when bypass login is true, and login hint is provided then ', () => {
+   it('if the user is assigned to an org with an idp, then they should be redirected automatically', () => {
       cy.visit(testRealmLoginUri + "&login_hint=" + idpUser.email);
       cy.url().should('contain', 'external-idp');
+      cy.get('#username').type(idpUser.username);
+      cy.get('#password').type(idpUser.password);
+      cy.get('#kc-login').click();
+
+      cy.contains('Personal');
+      cy.url().should('contain', 'test-realm');
+   });
+
+   it('if the user is not linked to an org, then the flow should prompt their username & password', () => {
+      cy.visit(testRealmLoginUri + "&login_hint=" + user1.email);
+      cy.url().should('contain', 'test-realm');
+      cy.get('#kc-login').click();
+      cy.get('#password').type(user1.password);
+      cy.get('#kc-login').click();
+
+      cy.contains('Personal');
+      cy.url().should('contain', 'test-realm');
+   });
+});
+
+describe('when bypass login is true, but login hint is not provided then the user should be prompted for their username', () => {
+   it('user which doesnt exists in the realm should receive an error ', () => {
+      cy.visit(testRealmLoginUri);
+      cy.get('#username').type(user2.username);
+      cy.get('#kc-login').click();
+
+      cy.get('#kc-error-message').should('exist');
+      cy.contains('Invalid');
+   })
+
+   it('user which doesnt have a domain associated to an organization but exists in the realm should login via username + password ', () => {
+      cy.visit(testRealmLoginUri);
+      cy.get('#username').type(user1.username);
+      cy.get('#kc-login').click();
+      cy.get('#password').type(user1.password);
+      cy.get('#kc-login').click();
+
+      cy.contains('Personal');
+   })
+
+   it('user which has a domain associated to an organization should login via idp SSO ', () => {
+      cy.visit(testRealmLoginUri);
+      cy.get('#username').type(idpUser.email);
+      cy.get('#kc-login').click();
+      cy.url().should('contain', 'external-idp');
+      cy.get('#username').type(idpUser.username);
+      cy.get('#password').type(idpUser.password);
+      cy.get('#kc-login').click();
+
+      cy.contains('Personal');
+      cy.url().should('contain', 'test-realm');
    })
 });

--- a/src/test/e2e/cypress/fixtures/users.ts
+++ b/src/test/e2e/cypress/fixtures/users.ts
@@ -6,7 +6,7 @@ type User = {
   email: string;
 }
 
-const user1: User = { username: "user-1", password: "user-1" };
+const user1: User = { username: "user-1", password: "user-1", email: "user-1@yahoo.com" };
 const user2: User = { username: "user-2", password: "user-2" };
 const user3: User = { username: "user-3", password: "user-3" };
 


### PR DESCRIPTION
During the review of  #379 while I processed the @rtufisi 's https://github.com/p2-inc/keycloak-orgs/pull/379#discussion_r2707279054 comment I found a small regression. 

Adding the passing integration tests first, so we can ensure that the transition is going to be smooth.