### PR TITLE
add integration tests for the IDP Validation flows from #411

### DIFF
--- a/src/test/e2e/cypress/e2e/home-idp-organization/base-with-idp-validation-enabled-and-unvalidated-idp.cy.ts
+++ b/src/test/e2e/cypress/e2e/home-idp-organization/base-with-idp-validation-enabled-and-unvalidated-idp.cy.ts
@@ -1,0 +1,42 @@
+import {testRealmLoginUri, testRealmUri} from "../../fixtures/uri";
+import { user1, user2, user3, idpUser } from "../../fixtures/users";
+
+describe('user login via home idp provider', () => {
+   it('user which doesnt exists in the realm should receive an error ', () => {
+      cy.visit(testRealmLoginUri);
+      cy.get('#username').type(user2.username);
+      cy.get('#kc-login').click();
+
+      cy.get('#kc-error-message').should('exist');
+      cy.contains('Invalid');
+   })
+
+  it('user which doesnt have a domain associated to an organization but exists in the realm should login via username + password ', () => {
+    cy.visit(testRealmLoginUri);
+    cy.get('#username').type(user1.username);
+    cy.get('#kc-login').click();
+    cy.get('#password').type(user1.password);
+    cy.get('#kc-login').click();
+
+    cy.contains('Personal');
+  })
+
+   it('user which has a domain associated to an organization should login via username + password if the idp is pending validation ', () => {
+       cy.visit(testRealmLoginUri);
+       cy.get('#username').type(idpUser.email);
+       cy.get('#kc-login').click();
+       cy.get('#social-oidc-idp').should('exist')
+       cy.get('#social-second-oidc').should('exist')
+       cy.get('#social-third-oidc').should('not.exist')
+       cy.url().should('contain', 'test-realm');
+
+       cy.get('#social-oidc-idp').click()
+       cy.url().should('contain', 'external-idp');
+       cy.get('#username').type(idpUser.username);
+       cy.get('#password').type(idpUser.password);
+       cy.get('#kc-login').click();
+
+       cy.contains('Personal');
+       cy.url().should('contain', testRealmUri);
+      })
+});

--- a/src/test/e2e/cypress/e2e/home-idp-organization/base-with-idp-validation-enabled-and-validated-idp.cy.ts
+++ b/src/test/e2e/cypress/e2e/home-idp-organization/base-with-idp-validation-enabled-and-validated-idp.cy.ts
@@ -1,0 +1,42 @@
+import {testRealmLoginUri, testRealmUri} from "../../fixtures/uri";
+import { user1, user2, user3, idpUser } from "../../fixtures/users";
+
+describe('user login via home idp provider', () => {
+   it('user which doesnt exists in the realm should receive an error ', () => {
+      cy.visit(testRealmLoginUri);
+      cy.get('#username').type(user2.username);
+      cy.get('#kc-login').click();
+
+      cy.get('#kc-error-message').should('exist');
+      cy.contains('Invalid');
+   })
+
+  it('user which doesnt have a domain associated to an organization but exists in the realm should login via username + password ', () => {
+    cy.visit(testRealmLoginUri);
+    cy.get('#username').type(user1.username);
+    cy.get('#kc-login').click();
+    cy.get('#password').type(user1.password);
+    cy.get('#kc-login').click();
+
+    cy.contains('Personal');
+  })
+
+   it('user which has a domain associated to an organization should login via username + password if the idp is pending validation ', () => {
+       cy.visit(testRealmLoginUri);
+       cy.get('#username').type(idpUser.email);
+       cy.get('#kc-login').click();
+       cy.get('#social-oidc-idp').should('exist')
+       cy.get('#social-second-oidc').should('exist')
+       cy.get('#social-third-oidc').should('exist')
+       cy.url().should('contain', 'test-realm');
+
+       cy.get('#social-oidc-idp').click()
+       cy.url().should('contain', 'external-idp');
+       cy.get('#username').type(idpUser.username);
+       cy.get('#password').type(idpUser.password);
+       cy.get('#kc-login').click();
+
+       cy.contains('Personal');
+       cy.url().should('contain', testRealmUri);
+      })
+});

--- a/src/test/java/io/phasetwo/web/AbstractCypressOrganizationTest.java
+++ b/src/test/java/io/phasetwo/web/AbstractCypressOrganizationTest.java
@@ -96,7 +96,6 @@ public class AbstractCypressOrganizationTest {
             .withContextPath("/auth")
             .withReuse(true)
             .withProviderClassesFrom("target/classes")
-            .withDebugFixedPort(8787, false)
             .withProviderLibsFrom(getDeps())
             .withAccessToHost(true);
     if (isJacocoPresent()) {

--- a/src/test/java/io/phasetwo/web/CypressHomeIdpOrganizationTest.java
+++ b/src/test/java/io/phasetwo/web/CypressHomeIdpOrganizationTest.java
@@ -30,8 +30,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
 import static io.phasetwo.service.Helpers.*;
-import static io.phasetwo.service.Orgs.ORG_CONFIG_MULTIPLE_IDPS_KEY;
-import static io.phasetwo.service.Orgs.ORG_DOMAIN_CONFIG_KEY;
+import static io.phasetwo.service.Orgs.*;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -88,6 +87,63 @@ class CypressHomeIdpOrganizationTest extends AbstractCypressOrganizationTest {
         realm.identityProviders().get(idp.getAlias()).update(idp);
         List<DynamicContainer> dynamicContainers = runCypressTests("", "cypress/e2e/home-idp-organization/base-with-disabled-org-idp.cy.ts");
         return dynamicContainers;
+    }
+
+    @TestFactory
+    @DisplayName("Test the IDP Validation attributes when pending IDPs could be present")
+    public Stream<DynamicContainer> idpValidationEnabledWithUnvalidatedIdp() throws IOException, InterruptedException, TimeoutException {
+        enum ThirdIdentityProviderValidated {
+            FALSE("There is an unvalidated IDP ", "cypress/e2e/home-idp-organization/base-with-idp-validation-enabled-and-unvalidated-idp.cy.ts"),
+            TRUE("All the IDPs are validated ", "cypress/e2e/home-idp-organization/base-with-idp-validation-enabled-and-validated-idp.cy.ts");
+
+            private final String testPrefix;
+            final String testFile;
+
+            ThirdIdentityProviderValidated(String testPrefix, String testFile) {
+                this.testPrefix = testPrefix;
+                this.testFile = testFile;
+            }
+        }
+
+        return Stream
+                .of(ThirdIdentityProviderValidated.values())
+                .map(thirdIdentityProviderValidated -> {
+                    try {
+                        setupKeycloakInstanceWithMultipleIdpsEnabledAtOrganization(); // sets up the keycloak with ~2 IDP configs
+                        final var realm = findRealmByName("test-realm");
+                        final var thirdClientRealm = importRealm("/realms/external-idp.json", "third-external-idp");
+
+                        final var thirdIdentityProvider = createIdentityProviderIn(realm, "third-oidc", false, "third-external-idp");
+                        String isIdpPending = Boolean.valueOf(!Boolean.parseBoolean(thirdIdentityProviderValidated.name().toLowerCase())).toString();
+                        thirdIdentityProvider.getConfig().put(ORG_VALIDATION_PENDING_CONFIG_KEY, isIdpPending);
+                        updateRedirectUriInClientRealm(thirdClientRealm, thirdIdentityProvider);
+                        realm.identityProviders().get(thirdIdentityProvider.getAlias()).update(thirdIdentityProvider);
+
+                        final var organization = findOrganizationRepresentationByName(realm.toRepresentation(), "org-home");
+                        linkIdentityProviderToOrganization(realm.toRepresentation(), organization, "third-oidc");
+
+                        modifyAuthenticatorConfig(
+                                "test-realm",
+                                "Copy of browser forms",
+                                "ext-auth-home-idp-discovery",
+                                Map.entry("forwardToFirstMatch", "false")
+                        );
+
+
+                        final var realmRepresentation = realm.toRepresentation();
+                        realmRepresentation.getAttributes().put(ORG_CONFIG_VALIDATE_IDP_KEY, "true");
+                        realm.update(realmRepresentation);
+
+                        List<DynamicContainer> dynamicContainers = runCypressTests(
+                                thirdIdentityProviderValidated.testPrefix,
+                                thirdIdentityProviderValidated.testFile
+                        );
+                        cleanupKeycloakInstance();
+                        return dynamicContainers;
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+        }).flatMap(List::stream);
     }
 
     @TestFactory


### PR DESCRIPTION
Adding integration tests for #411, so we can test these flows as well during the HomeIDP update (#379)