### PR TITLE
Integrate Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI Build
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  build:
+    name: Build Project with Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Java 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Build with Maven and run Cypress Integration Tests
+        run: mvn --batch-mode --update-snapshots verify -Pcypress-tests
+      - name: Upload JaCoCo Coverage Report as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: ${{ github.workspace }}/target/site/jacoco/
+          retention-days: 30
+      - name: Add JaCoCo Coverage to Action Summary
+        uses: jjmrocha/jacoco-summary@v1.1.1
+        with:
+          jacoco-csv-file: target/site/jacoco/jacoco.csv

--- a/.github/workflows/jacoco-pr-comment.yml
+++ b/.github/workflows/jacoco-pr-comment.yml
@@ -1,0 +1,32 @@
+name: PR Coverage Comment
+on:
+  workflow_run:
+    workflows: ["CI Build"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  comment:
+    name: Comment Jacoco Report to PR safely
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: jacoco-report
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Add JaCoCo coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.7.2
+        with:
+          paths: |
+            ${{ github.workspace }}/target/site/jacoco/jacoco.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Code Coverage
+          update-comment: true


### PR DESCRIPTION
Integrated GitHub Actions into this repository. It seems to work well and publishes JaCoCo artifacts as expected.

Closes #417 

# Open questions

The issue raised two open questions:

**When should CI run?**

> On every PR automatically? Or should CI for 3rd-party PRs wait for maintainer approval? Should we consider running unit tests for everyone, but only run integration tests for pre-approved PRs?

If I understand the [GitHub docs](https://docs.github.com/en/billing/concepts/product-billing/github-actions#how-use-of-github-actions-is-measured) correctly, open source repositories can use GitHub-hosted runners for free. If that’s the case, I’d suggest running all jobs for every PR for now, and optimizing this later if needed.

> GitHub Actions usage is free for self-hosted runners and for public repositories that use standard GitHub-hosted runners.

**Keycloak version coverage**

> Do we want to test against multiple Keycloak versions in CI?

Any thoughts on this @xgp @rtufisi? My view is no: we only support the latest Keycloak version with the latest plugin version, so testing against older versions would add maintenance overhead without clear benefit.