### PR TITLE
Custom DNS Record Key Config

### DIFF
--- a/src/main/java/io/phasetwo/service/Orgs.java
+++ b/src/main/java/io/phasetwo/service/Orgs.java
@@ -29,6 +29,7 @@ public class Orgs {
   public static final String ORG_VALIDATION_PENDING_CONFIG_KEY =
       "home.idp.discovery.validationPending";
   public static final String ORG_SHARED_IDP_KEY = "home.idp.discovery.shared";
+  public static final String ORG_DNS_RECORD_KEY = "_providerConfig.orgs.dnsRecordKey";
 
   public static final String REQUIRE_VERIFIED_DOMAIN = "requireVerifiedDomain";
   public static final String REQUIRE_VALID_EMAIL = "requireValidEmail";

--- a/src/main/java/io/phasetwo/service/resource/DomainsResource.java
+++ b/src/main/java/io/phasetwo/service/resource/DomainsResource.java
@@ -1,5 +1,6 @@
 package io.phasetwo.service.resource;
 
+import static io.phasetwo.service.Orgs.ORG_DNS_RECORD_KEY;
 import static io.phasetwo.service.resource.OrganizationResourceType.DOMAIN;
 
 import com.google.common.base.Joiner;
@@ -17,6 +18,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.events.admin.OperationType;
@@ -31,9 +33,13 @@ public class DomainsResource extends OrganizationAdminResource {
 
   private final OrganizationModel organization;
 
+  private final String recordKey;
+
   public DomainsResource(OrganizationAdminResource parent, OrganizationModel organization) {
     super(parent);
     this.organization = organization;
+    this.recordKey =
+        Optional.ofNullable(realm.getAttribute(ORG_DNS_RECORD_KEY)).orElse("_org-domain-ownership");
   }
 
   @GET
@@ -56,14 +62,12 @@ public class DomainsResource extends OrganizationAdminResource {
     return new Domain()
         .domainName(d.getDomain())
         .verified(d.isVerified())
-        .recordKey(RECORD_KEY)
+        .recordKey(recordKey)
         .recordValue(getRecordValue(d.getDomain()));
   }
 
-  private static final String RECORD_KEY = "_org-domain-ownership";
-
   private String getRecordKey(String domainName) {
-    return String.format("%s.%s", RECORD_KEY, domainName);
+    return String.format("%s.%s", recordKey, domainName);
   }
 
   private String getRecordValue(String domainName) {


### PR DESCRIPTION
Add a realm attribute `_providerConfig.orgs.dnsRecordKey` that will override the default DNS record key (`_org-domain-ownership`) for domain verification to allow per-realm / custom TXT record domain selection.