### PR TITLE
Fix Github Actions: Code Coverage is posted to PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI Build
 on:
   push:
     branches:
-      - '**'
+      - 'main'
   pull_request:
 
 jobs:
@@ -20,7 +20,7 @@ jobs:
       - name: Build with Maven and run Cypress Integration Tests
         run: mvn --batch-mode --update-snapshots verify -Pcypress-tests
       - name: Upload JaCoCo Coverage Report as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: jacoco-report
           path: ${{ github.workspace }}/target/site/jacoco/

--- a/.github/workflows/jacoco-pr-comment.yml
+++ b/.github/workflows/jacoco-pr-comment.yml
@@ -10,23 +10,57 @@ permissions:
   contents: read
 
 jobs:
+  # see the discussion here: https://github.com/orgs/community/discussions/25220#discussioncomment-11285971
+  # and here: https://github.com/docker-mailserver/docker-mailserver/pull/4267#issuecomment-2484565209
+  pr-context:
+    name: 'Acquire PR Context'
+    runs-on: ubuntu-24.04
+    outputs:
+      PR_HEADSHA: ${{ steps.set-pr-context.outputs.head-sha }}
+      PR_NUMBER: ${{ steps.set-pr-context.outputs.number   }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    steps:
+      - name: 'Get PR context'
+        id: set-pr-context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_TARGET_REPO: ${{ github.repository }}
+          PR_BRANCH: |-
+            ${{
+              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+                || github.event.workflow_run.head_branch
+            }}
+        run: |
+          gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" \
+            --json 'number,headRefOid' \
+            --jq '"number=\(.number)\nhead-sha=\(.headRefOid)"' \
+            >> $GITHUB_OUTPUT
+
   comment:
     name: Comment Jacoco Report to PR safely
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    needs: [pr-context]
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v7
+        id: download-artifact
+        uses: actions/download-artifact@v6
         with:
           name: jacoco-report
           run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ github.workspace }}/jacoco
 
       - name: Add JaCoCo coverage to PR
         id: jacoco
-        uses: madrapps/jacoco-report@v1.7.2
+        uses:  vilmosnagy/jacoco-report@1.7.2-v2
         with:
           paths: |
-            ${{ github.workspace }}/target/site/jacoco/jacoco.xml
+            ${{ steps.download-artifact.outputs.download-path }}/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           title: Code Coverage
           update-comment: true
+          debug-mode: true
+          pr-number: ${{ needs.pr-context.outputs.PR_NUMBER  }}
+          head-sha: ${{ needs.pr-context.outputs.PR_HEADSHA }}


### PR DESCRIPTION
follow up from https://github.com/p2-inc/keycloak-orgs/pull/427

The Code Coverage in the previous commit contained a bug, and the jacoco summary is not posted to the PRs when the PR is opened from a fork.

After this the summary is posted to the PR as a comment in both cases:
 - when the PR is opened from the same repo
 - when the PR is opened from a fork

Posting to PRs from forked repos only works with the `on: workflow_run` event, but that event does not populate the Github Actions context the same way as if the PR was opened from the same repo.

When the PR was opened from a fork the `prNumber` and the `headSha` was not included correctly.

The used solution was inspired by the linked github discussions.

Had to fork the jacoco-report action, 'cause the upstream action do support to provide the pr-number from outside, but did not support to provide the headSha of the PR.