### PR TITLE
feat: add conditional authenticator that matches org and client attributes at runtime

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/ConditionalOrgAttributeMatchesClientAttribute.java
+++ b/src/main/java/io/phasetwo/service/auth/ConditionalOrgAttributeMatchesClientAttribute.java
@@ -1,0 +1,133 @@
+package io.phasetwo.service.auth;
+
+import static io.phasetwo.service.Orgs.ACTIVE_ORGANIZATION;
+
+import io.phasetwo.service.model.OrganizationProvider;
+import java.util.Map;
+import lombok.extern.jbosslog.JBossLog;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+/**
+ * Conditional authenticator that checks whether the authenticating user belongs to a Phase Two
+ * organization whose attribute matches a value read from the current OIDC client's attributes.
+ *
+ * <p>This enables per-client tenant enforcement with a single realm-wide Post Broker Login flow.
+ *
+ * <p><b>IMPORTANT:</b> This authenticator requires a user and must be placed in Post Broker Login
+ * or First Broker Login flows, NOT in the Browser flow before IdP redirect completes.
+ */
+@JBossLog
+public class ConditionalOrgAttributeMatchesClientAttribute implements ConditionalAuthenticator {
+
+  static final ConditionalOrgAttributeMatchesClientAttribute SINGLETON =
+      new ConditionalOrgAttributeMatchesClientAttribute();
+
+  @Override
+  public boolean matchCondition(AuthenticationFlowContext context) {
+    // Retrieve configuration
+    Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+    String orgAttrName =
+        config.get(
+            ConditionalOrgAttributeMatchesClientAttributeFactory.CONF_ORG_ATTRIBUTE_NAME);
+    String clientAttrName =
+        config.get(
+            ConditionalOrgAttributeMatchesClientAttributeFactory.CONF_CLIENT_ATTRIBUTE_NAME);
+    boolean negateOutput =
+        Boolean.parseBoolean(
+            config.get(ConditionalOrgAttributeMatchesClientAttributeFactory.CONF_NEGATE));
+
+    // Validate config — fail closed if misconfigured
+    if (orgAttrName == null || orgAttrName.isBlank() || clientAttrName == null
+        || clientAttrName.isBlank()) {
+      log.warnf(
+          "Condition config incomplete: orgAttr=[%s], clientAttr=[%s]. Returning no-match (fail closed).",
+          orgAttrName, clientAttrName);
+      return negateOutput;
+    }
+
+    // Read expected value from the current client's attributes
+    ClientModel client = context.getAuthenticationSession().getClient();
+    String expectedValue = client.getAttribute(clientAttrName);
+
+    if (expectedValue == null || expectedValue.isBlank()) {
+      log.infof(
+          "Client [%s] has no attribute [%s]. Returning no-match (fail closed).",
+          client.getClientId(), clientAttrName);
+      return negateOutput;
+    }
+
+    // Get Phase Two OrganizationProvider
+    KeycloakSession session = context.getSession();
+    RealmModel realm = context.getRealm();
+    UserModel user = context.getUser();
+
+    OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+    if (orgProvider == null) {
+      log.errorf(
+          "OrganizationProvider not available. Is Phase Two keycloak-orgs deployed? Returning no-match (fail closed).");
+      return negateOutput;
+    }
+
+    // Check user's org memberships for a matching attribute
+    boolean match =
+        orgProvider
+            .getUserOrganizationsStream(realm, user)
+            .anyMatch(
+                org -> {
+                  boolean orgMatch;
+                  try {
+                    orgMatch = org.hasAttribute(orgAttrName, expectedValue);
+                  } catch (NoSuchMethodError e) {
+                    // Fallback for older Phase Two versions
+                    orgMatch =
+                        org.getAttributes()
+                            .getOrDefault(orgAttrName, java.util.List.of())
+                            .contains(expectedValue);
+                  }
+                  if (orgMatch) {
+                    log.debugf(
+                        "Org [%s] (id=%s) matches: %s=%s",
+                        org.getName(), org.getId(), orgAttrName, expectedValue);
+                  }
+                  return orgMatch;
+                });
+
+    log.infof(
+        "Condition for user [%s], client [%s]: orgAttr[%s] == clientAttr[%s](value=[%s]) → match=%b, negate=%b, final=%b",
+        user.getUsername(),
+        client.getClientId(),
+        orgAttrName,
+        clientAttrName,
+        expectedValue,
+        match,
+        negateOutput,
+        negateOutput != match);
+
+    return negateOutput != match;
+  }
+
+  @Override
+  public void action(AuthenticationFlowContext context) {
+    // no-op
+  }
+
+  @Override
+  public boolean requiresUser() {
+    return true;
+  }
+
+  @Override
+  public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+    // no-op
+  }
+
+  @Override
+  public void close() {
+    // no-op
+  }
+}

--- a/src/main/java/io/phasetwo/service/auth/ConditionalOrgAttributeMatchesClientAttributeFactory.java
+++ b/src/main/java/io/phasetwo/service/auth/ConditionalOrgAttributeMatchesClientAttributeFactory.java
@@ -1,0 +1,122 @@
+package io.phasetwo.service.auth;
+
+import java.util.List;
+import org.keycloak.Config;
+import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator;
+import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+/**
+ * Factory for {@link ConditionalOrgAttributeMatchesClientAttribute}.
+ *
+ * <p>Registers a conditional authenticator that compares a Phase Two organization attribute
+ * against a value read from the current OIDC client's attributes at runtime.
+ */
+public class ConditionalOrgAttributeMatchesClientAttributeFactory
+    implements ConditionalAuthenticatorFactory {
+
+  /** SPI provider ID — must be unique across all deployed providers. MAX 36 chars (DB column limit). */
+  public static final String PROVIDER_ID = "conditional-org-client-attr";
+
+  // --- Config property keys ---
+
+  /** The key of the organization attribute to check. Example: {@code "tenant_id"} */
+  public static final String CONF_ORG_ATTRIBUTE_NAME = "org_attribute_name";
+
+  /**
+   * The key of the client attribute that holds the expected value. Example: {@code "tenant_id"}
+   * (set on the client entity, not a protocol mapper)
+   */
+  public static final String CONF_CLIENT_ATTRIBUTE_NAME = "client_attribute_name";
+
+  /** Whether to invert the match result. When {@code true}, the subflow fires when the attribute does NOT match. */
+  public static final String CONF_NEGATE = "negate_output";
+
+  // --- Config property definitions (rendered in the Admin Console) ---
+
+  private static final List<ProviderConfigProperty> CONFIG_PROPERTIES =
+      List.of(
+          new ProviderConfigProperty(
+              CONF_ORG_ATTRIBUTE_NAME,
+              "Org attribute name",
+              "The organization attribute key to check (e.g. tenant_id).",
+              ProviderConfigProperty.STRING_TYPE,
+              ""),
+          new ProviderConfigProperty(
+              CONF_CLIENT_ATTRIBUTE_NAME,
+              "Client attribute name",
+              "The client attribute key that holds the expected value (e.g. tenant_id). Read from the current OIDC client at runtime.",
+              ProviderConfigProperty.STRING_TYPE,
+              ""),
+          new ProviderConfigProperty(
+              CONF_NEGATE,
+              "Negate output",
+              "Invert the condition result. When ON, the subflow executes only when the attribute does NOT match.",
+              ProviderConfigProperty.BOOLEAN_TYPE,
+              "false"));
+
+  @Override
+  public ConditionalAuthenticator getSingleton() {
+    return ConditionalOrgAttributeMatchesClientAttribute.SINGLETON;
+  }
+
+  @Override
+  public String getId() {
+    return PROVIDER_ID;
+  }
+
+  @Override
+  public String getDisplayType() {
+    return "Condition - org attribute matches client attribute";
+  }
+
+  @Override
+  public String getReferenceCategory() {
+    return "condition";
+  }
+
+  @Override
+  public String getHelpText() {
+    return "Matches when the authenticating user belongs to a Phase Two organization whose attribute (e.g. tenant_id) equals the value of the specified attribute on the current OIDC client. Designed for per-client tenant enforcement in multi-tenant IdP setups.";
+  }
+
+  @Override
+  public boolean isConfigurable() {
+    return true;
+  }
+
+  @Override
+  public boolean isUserSetupAllowed() {
+    return false;
+  }
+
+  @Override
+  public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+    return new AuthenticationExecutionModel.Requirement[] {
+      AuthenticationExecutionModel.Requirement.REQUIRED,
+      AuthenticationExecutionModel.Requirement.DISABLED
+    };
+  }
+
+  @Override
+  public List<ProviderConfigProperty> getConfigProperties() {
+    return CONFIG_PROPERTIES;
+  }
+
+  @Override
+  public void init(Config.Scope scope) {
+    // no-op
+  }
+
+  @Override
+  public void postInit(KeycloakSessionFactory factory) {
+    // no-op
+  }
+
+  @Override
+  public void close() {
+    // no-op
+  }
+}

--- a/src/main/java/io/phasetwo/service/auth/ConditionalOrgAttributeMatchesClientAttributeFactory.java
+++ b/src/main/java/io/phasetwo/service/auth/ConditionalOrgAttributeMatchesClientAttributeFactory.java
@@ -1,7 +1,9 @@
 package io.phasetwo.service.auth;
 
+import com.google.auto.service.AutoService;
 import java.util.List;
 import org.keycloak.Config;
+import org.keycloak.authentication.AuthenticatorFactory;
 import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator;
 import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticatorFactory;
 import org.keycloak.models.AuthenticationExecutionModel;
@@ -14,6 +16,7 @@ import org.keycloak.provider.ProviderConfigProperty;
  * <p>Registers a conditional authenticator that compares a Phase Two organization attribute
  * against a value read from the current OIDC client's attributes at runtime.
  */
+@AutoService(AuthenticatorFactory.class)
 public class ConditionalOrgAttributeMatchesClientAttributeFactory
     implements ConditionalAuthenticatorFactory {
 


### PR DESCRIPTION
## Summary
This PR adds a new conditional authenticator that compares a user organization attribute against a client attribute value resolved at login time.

It is intended for multi-tenant setups where each OIDC client carries a tenant marker such as `tenant_id`, and authentication should continue only when the user belongs to a matching organization.

## What is added
- `ConditionalOrgAttributeMatchesClientAttribute`
- `ConditionalOrgAttributeMatchesClientAttributeFactory`
- Provider ID: `conditional-org-client-attr`

## Behavior
Config properties:
- `org_attribute_name` (`String`): organization attribute key to check, for example `tenant_id`
- `client_attribute_name` (`String`): client attribute key containing the expected value
- `negate_output` (`Boolean`): invert the result

Evaluation flow:
1. Read the current client attribute value using `client_attribute_name`
2. Enumerate the user’s organization memberships
3. Return a match if any organization has `org_attribute_name == clientAttributeValue`
4. Apply `negate_output` when configured

## Why this is needed
The existing `ConditionalOrgAttributeValue` provider compares an organization attribute against a static value configured in the authenticator.

This new provider allows the expected value to come from the current client at runtime, so one shared flow can work across many tenant-specific clients without duplicating flows per tenant.

## Security model
The provider is fail-closed by design.

Missing config, missing client attribute, missing `OrganizationProvider`, or empty memberships evaluate to no-match.

## Validation
- Maven package build passed
- The built jar contains the new authenticator classes
- The factory is registered for discovery and the provider is visible at runtime as `conditional-org-client-attr`
<img width="852" height="915" alt="Screenshot from2026-03-10 23-41-59" src="https://github.com/user-attachments/assets/e13895be-4773-4d2b-a155-5f1c708a6fdc" />

<img width="637" height="732" alt="image" src="https://github.com/user-attachments/assets/2a468226-19ec-4fa5-a59b-500e3f0661ed" />



## Notes
- This PR adds a new provider alongside the existing `ConditionalOrgAttributeValue`; it does not modify the behavior of the existing provider.
- Implementation follows the existing condition/factory pattern in this module and keeps scope limited to a new condition.
