### PR TITLE
Fix org role migration performance and add test coverage (#443)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>1.21.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.7.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.dasniko</groupId>
       <artifactId>testcontainers-keycloak</artifactId>
       <version>4.1.1</version>

--- a/src/main/java/io/phasetwo/service/Orgs.java
+++ b/src/main/java/io/phasetwo/service/Orgs.java
@@ -12,6 +12,8 @@ public class Orgs {
   public static final String ORG_DEFAULT_SYNC_MODE_KEY = "_providerConfig.orgs.defaults.syncMode";
   public static final String ACTIVE_ORGANIZATION = "org.ro.active";
   public static final String KC_ORGS_SKIP_MIGRATION = System.getenv("KC_ORGS_SKIP_MIGRATION");
+  public static final int KC_ORGS_MIGRATION_BATCH_SIZE =
+      Integer.parseInt(System.getenv().getOrDefault("KC_ORGS_MIGRATION_BATCH_SIZE", "500"));
   public static final String ORG_BROWSER_AUTH_FLOW_ALIAS = "Org Browser Flow";
   public static final String ORG_DIRECT_GRANT_AUTH_FLOW_ALIAS = "Org Direct Grant Flow";
   public static final String IDP_VALIDATE_FLOW_ALIAS = "idp validate";

--- a/src/main/java/io/phasetwo/service/model/OrganizationProvider.java
+++ b/src/main/java/io/phasetwo/service/model/OrganizationProvider.java
@@ -2,6 +2,8 @@ package io.phasetwo.service.model;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
+
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -48,6 +50,8 @@ public interface OrganizationProvider extends Provider {
 
   Stream<IdentityProviderModel> getIdentityProvidersStream(
       RealmModel realm, String configKey, String configValue, boolean exact);
+
+  Collection<? extends OrganizationModel> getOrganizationsMissingRole(String roleName, int batchSize);
 
   // deprecated methods
 

--- a/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java
+++ b/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java
@@ -26,11 +26,15 @@ import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -246,6 +250,22 @@ public class JpaOrganizationProvider implements OrganizationProvider {
       RealmModel realm, String configKey, String configValue, boolean exact) {
     return IdentityProviders.getIdentityProvidersStream(
         session, em, realm, configKey, configValue, exact);
+  }
+
+  @Override
+  public Collection<? extends OrganizationModel> getOrganizationsMissingRole(String roleName, int batchSize) {
+    EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+    final var orgs = em.createNamedQuery("getOrganizationsMissingRole", ExtOrganizationEntity.class)
+                    .setParameter("roleName", roleName)
+                    .setMaxResults(batchSize)
+                    .getResultList();
+
+    Set<String> realmIds = orgs.stream().map(ExtOrganizationEntity::getRealmId).collect(Collectors.toSet());
+    Map<String, RealmModel> realms = realmIds.stream().collect(Collectors.toMap(id -> id, id -> session.realms().getRealm(id)));
+    return orgs
+            .stream()
+            .map(org -> new OrganizationAdapter(session, realms.get(org.getRealmId()), em, org))
+            .toList();
   }
 
   @Override

--- a/src/main/java/io/phasetwo/service/model/jpa/entity/ExtOrganizationEntity.java
+++ b/src/main/java/io/phasetwo/service/model/jpa/entity/ExtOrganizationEntity.java
@@ -32,7 +32,15 @@ import org.hibernate.annotations.Nationalized;
       query = "select count(o) from ExtOrganizationEntity o where o.realmId = :realmId"),
   @NamedQuery(
       name = "removeAllOrganizations",
-      query = "delete from ExtOrganizationEntity o where o.realmId = :realmId")
+      query = "delete from ExtOrganizationEntity o where o.realmId = :realmId"),
+  @NamedQuery(
+      name = "getOrganizationsMissingRole",
+      query =
+          "SELECT o FROM ExtOrganizationEntity o"
+              + " WHERE NOT EXISTS ("
+              + "   SELECT r FROM OrganizationRoleEntity r"
+              + "   WHERE r.organization = o AND r.name = :roleName"
+              + ")")
 })
 @Entity
 @Table(

--- a/src/main/java/io/phasetwo/service/resource/OrganizationResourceProviderFactory.java
+++ b/src/main/java/io/phasetwo/service/resource/OrganizationResourceProviderFactory.java
@@ -15,9 +15,9 @@ import com.google.common.base.Strings;
 import io.phasetwo.service.model.OrganizationModel;
 import io.phasetwo.service.model.OrganizationProvider;
 import io.phasetwo.service.model.OrganizationRoleModel;
+import io.phasetwo.service.model.jpa.JpaOrganizationProvider;
 import io.phasetwo.service.model.jpa.entity.ExtOrganizationEntity;
 import io.phasetwo.service.util.IdentityProviders;
-import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -132,27 +132,14 @@ public class OrganizationResourceProviderFactory implements RealmResourceProvide
   }
 
   private int processOrgRoleMigrationBatch(KeycloakSession session, String roleName) {
-    EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
-    List<ExtOrganizationEntity> orgs =
-        em.createNamedQuery("getOrganizationsMissingRole", ExtOrganizationEntity.class)
-            .setParameter("roleName", roleName)
-            .setMaxResults(KC_ORGS_MIGRATION_BATCH_SIZE)
-            .getResultList();
+    final var orgs = session
+            .getProvider(OrganizationProvider.class)
+            .getOrganizationsMissingRole(roleName, KC_ORGS_MIGRATION_BATCH_SIZE);
 
-    Map<String, List<ExtOrganizationEntity>> orgsByRealm = orgs
-            .stream()
-            .collect(Collectors.groupingBy(ExtOrganizationEntity::getRealmId));
-
-    for (var orgsGroupedByRealm : orgsByRealm.entrySet()) {
-      final var realmId = orgsGroupedByRealm.getKey();
-      final var realm = session.realms().getRealm(realmId);
-      final var orgsInRealm = orgsGroupedByRealm.getValue();
-      for (ExtOrganizationEntity orgEntity : orgsInRealm) {
-        final var org = session.getProvider(OrganizationProvider.class).getOrganizationById(realm, orgEntity.getId());
-        OrganizationRoleModel role = org.addRole(roleName);
-        role.setDescription(DEFAULT_ORG_ROLES_DESC.get(roleName));
-        log.debugf("Added %s role to organization %s", roleName, org.getId());
-      }
+    for (final var org : orgs) {
+      OrganizationRoleModel role = org.addRole(roleName);
+      role.setDescription(DEFAULT_ORG_ROLES_DESC.get(roleName));
+      log.debugf("Added %s role to organization %s", roleName, org.getId());
     }
     return orgs.size();
   }

--- a/src/main/java/io/phasetwo/service/resource/OrganizationResourceProviderFactory.java
+++ b/src/main/java/io/phasetwo/service/resource/OrganizationResourceProviderFactory.java
@@ -1,5 +1,6 @@
 package io.phasetwo.service.resource;
 
+import static io.phasetwo.service.Orgs.KC_ORGS_MIGRATION_BATCH_SIZE;
 import static io.phasetwo.service.Orgs.KC_ORGS_SKIP_MIGRATION;
 import static io.phasetwo.service.Orgs.ORG_CONFIG_CREATE_ADMIN_USER_KEY;
 import static io.phasetwo.service.resource.OrganizationAdminAuth.DEFAULT_ORG_ROLES;
@@ -14,10 +15,16 @@ import com.google.common.base.Strings;
 import io.phasetwo.service.model.OrganizationModel;
 import io.phasetwo.service.model.OrganizationProvider;
 import io.phasetwo.service.model.OrganizationRoleModel;
+import io.phasetwo.service.model.jpa.entity.ExtOrganizationEntity;
 import io.phasetwo.service.util.IdentityProviders;
+import jakarta.persistence.EntityManager;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
 import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.Config;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
@@ -70,6 +77,7 @@ public class OrganizationResourceProviderFactory implements RealmResourceProvide
             if (KC_ORGS_SKIP_MIGRATION == null) {
               log.info("initializing organization roles following migration");
               KeycloakModelUtils.runJobInTransaction(factory, this::initRoles);
+              migrateOrganizationWithNewDefaultRolesBatched(factory, ORG_ROLE_DELETE_ORGANIZATION);
             }
           } else if (event instanceof RealmModel.RealmRemovedEvent) {
             log.debug("RealmRemovedEvent");
@@ -110,27 +118,43 @@ public class OrganizationResourceProviderFactory implements RealmResourceProvide
                   addRealmAdminRoles(manager, realm);
                 }
               }
-
-              // Update existing organizations with the new delete-organization role
-              updateExistingOrganizationsWithNewRoles(session, realm);
             });
   }
 
-  private void updateExistingOrganizationsWithNewRoles(KeycloakSession session, RealmModel realm) {
-    log.debug("Updating existing organizations with new default roles");
-    session
-        .getProvider(OrganizationProvider.class)
-        .getOrganizationsStream(realm)
-        .forEach(
-            org -> {
-              // Check if the delete-organization role exists, if not add it
-              if (org.getRoleByName(ORG_ROLE_DELETE_ORGANIZATION) == null) {
-                OrganizationRoleModel role = org.addRole(ORG_ROLE_DELETE_ORGANIZATION);
-                role.setDescription(DEFAULT_ORG_ROLES_DESC.get(ORG_ROLE_DELETE_ORGANIZATION));
-                log.debugf(
-                    "Added %s role to organization %s", ORG_ROLE_DELETE_ORGANIZATION, org.getId());
-              }
-            });
+  private void migrateOrganizationWithNewDefaultRolesBatched(KeycloakSessionFactory factory, String roleName) {
+    log.infof("Migrating missing org roles across all realms (batch size: %d)", KC_ORGS_MIGRATION_BATCH_SIZE);
+    int[] batchCount = {KC_ORGS_MIGRATION_BATCH_SIZE};
+    while (batchCount[0] == KC_ORGS_MIGRATION_BATCH_SIZE) {
+      KeycloakModelUtils.runJobInTransaction(factory, session -> batchCount[0] = processOrgRoleMigrationBatch(session, roleName));
+      log.infof("Migrated %d organizations with the added role %s...", batchCount[0], roleName);
+    }
+    log.info("Organization role migration complete");
+  }
+
+  private int processOrgRoleMigrationBatch(KeycloakSession session, String roleName) {
+    EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+    List<ExtOrganizationEntity> orgs =
+        em.createNamedQuery("getOrganizationsMissingRole", ExtOrganizationEntity.class)
+            .setParameter("roleName", roleName)
+            .setMaxResults(KC_ORGS_MIGRATION_BATCH_SIZE)
+            .getResultList();
+
+    Map<String, List<ExtOrganizationEntity>> orgsByRealm = orgs
+            .stream()
+            .collect(Collectors.groupingBy(ExtOrganizationEntity::getRealmId));
+
+    for (var orgsGroupedByRealm : orgsByRealm.entrySet()) {
+      final var realmId = orgsGroupedByRealm.getKey();
+      final var realm = session.realms().getRealm(realmId);
+      final var orgsInRealm = orgsGroupedByRealm.getValue();
+      for (ExtOrganizationEntity orgEntity : orgsInRealm) {
+        final var org = session.getProvider(OrganizationProvider.class).getOrganizationById(realm, orgEntity.getId());
+        OrganizationRoleModel role = org.addRole(roleName);
+        role.setDescription(DEFAULT_ORG_ROLES_DESC.get(roleName));
+        log.debugf("Added %s role to organization %s", roleName, org.getId());
+      }
+    }
+    return orgs.size();
   }
 
   private void realmPostCreate(RealmModel.RealmPostCreateEvent event) {

--- a/src/test/java/io/phasetwo/service/AbstractOrganizationTest.java
+++ b/src/test/java/io/phasetwo/service/AbstractOrganizationTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.phasetwo.client.openapi.model.OrganizationRepresentation;
 import io.phasetwo.client.openapi.model.OrganizationRoleRepresentation;
+import io.phasetwo.service.KeycloakOrgsAdminAPI;
 import io.phasetwo.service.importexport.representation.InvitationRepresentation;
 import io.phasetwo.service.importexport.representation.KeycloakOrgsRepresentation;
 import io.phasetwo.service.importexport.representation.UserRolesRepresentation;
@@ -43,6 +44,7 @@ import org.hamcrest.Matchers;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
@@ -210,108 +212,36 @@ public abstract class AbstractOrganizationTest {
   }
 
   protected List<OrganizationRepresentation> listOrganizations() throws JsonProcessingException {
-    Response response = givenSpec(keycloak).get();
-    assertThat(response.statusCode(), Matchers.is(Status.OK.getStatusCode()));
-    return objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+    return getKeycloakOrgsAdminAPI(REALM, keycloak).listOrganizations();
   }
 
-  // create an organization, fetch the created organization and returns it
+  private static @NotNull KeycloakOrgsAdminAPI getKeycloakOrgsAdminAPI(String realm, Keycloak keycloak) {
+    return new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), realm, keycloak);
+  }
+
   protected OrganizationRepresentation createOrganization(
       Keycloak keycloak, OrganizationRepresentation representation) throws IOException {
-    Response response =
-        givenSpec(keycloak).and().body(toJsonString(representation)).when().post().andReturn();
-
-    assertThat(response.getStatusCode(), is(Status.CREATED.getStatusCode()));
-    assertNotNull(response.getHeader("Location"));
-    String loc = response.getHeader("Location");
-    String id = loc.substring(loc.lastIndexOf("/") + 1);
-
-    response = getRequest(id);
-    assertThat(response.statusCode(), Matchers.is(Status.OK.getStatusCode()));
-    OrganizationRepresentation orgRep =
-        objectMapper().readValue(response.getBody().asString(), OrganizationRepresentation.class);
-    assertThat(orgRep.getId(), is(id));
-    return orgRep;
+    return getKeycloakOrgsAdminAPI(REALM, keycloak).createOrganization(representation);
   }
 
   protected KeycloakOrgsRepresentation exportOrgs(
       Keycloak keycloak, boolean exportMembersAndInvitations) throws IOException {
-    var response =
-        given()
-            .baseUri(container.getAuthServerUrl())
-            .basePath("realms/" + REALM + "/orgs")
-            .contentType("application/json")
-            .auth()
-            .oauth2(keycloak.tokenManager().getAccessTokenString())
-            .queryParam("exportMembersAndInvitations", exportMembersAndInvitations)
-            .when()
-            .get("export")
-            .then()
-            .extract()
-            .response();
-
-    return objectMapper()
-        .readValue(response.getBody().asString(), KeycloakOrgsRepresentation.class);
+    return getKeycloakOrgsAdminAPI(REALM, keycloak).exportOrgs(exportMembersAndInvitations);
   }
 
   protected Response importOrgs(
       KeycloakOrgsRepresentation representation, Keycloak keycloak, String realm) {
-    return given()
-        .baseUri(container.getAuthServerUrl())
-        .basePath("realms/" + realm + "/orgs")
-        .contentType("application/json")
-        .auth()
-        .oauth2(keycloak.tokenManager().getAccessTokenString())
-        .queryParam("skipMissingMember", false)
-        .queryParam("skipMissingIdp", false)
-        .when()
-        .and()
-        .body(representation)
-        .when()
-        .post("import")
-        .then()
-        .extract()
-        .response();
+    return getKeycloakOrgsAdminAPI(realm, keycloak).importOrgs(representation, false, false);
   }
 
   protected Response importOrgsSkipMissingMembers(
       KeycloakOrgsRepresentation representation, Keycloak keycloak, String realm) {
-    return given()
-        .baseUri(container.getAuthServerUrl())
-        .basePath("realms/" + realm + "/orgs")
-        .contentType("application/json")
-        .auth()
-        .oauth2(keycloak.tokenManager().getAccessTokenString())
-        .queryParam("skipMissingMember", true)
-        .queryParam("skipMissingIdp", false)
-        .when()
-        .and()
-        .body(representation)
-        .when()
-        .post("import")
-        .then()
-        .extract()
-        .response();
+    return getKeycloakOrgsAdminAPI(realm, keycloak).importOrgs(representation, true, false);
   }
 
   protected Response importOrgSkipMissingIdp(
       KeycloakOrgsRepresentation representation, Keycloak keycloak, String realm) {
-    return given()
-        .baseUri(container.getAuthServerUrl())
-        .basePath("realms/" + realm + "/orgs")
-        .contentType("application/json")
-        .auth()
-        .oauth2(keycloak.tokenManager().getAccessTokenString())
-        .queryParam("skipMissingMember", false)
-        .queryParam("skipMissingIdp", true)
-        .when()
-        .and()
-        .body(representation)
-        .when()
-        .post("import")
-        .then()
-        .extract()
-        .response();
+    return getKeycloakOrgsAdminAPI(realm, keycloak).importOrgs(representation, false, true);
   }
 
   protected void importRealm(RealmRepresentation representation, Keycloak keycloak) {

--- a/src/test/java/io/phasetwo/service/KeycloakOrgsAdminAPI.java
+++ b/src/test/java/io/phasetwo/service/KeycloakOrgsAdminAPI.java
@@ -1,0 +1,119 @@
+package io.phasetwo.service;
+
+import static io.phasetwo.service.Helpers.objectMapper;
+import static io.phasetwo.service.Helpers.toJsonString;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.phasetwo.client.openapi.model.OrganizationRepresentation;
+import io.phasetwo.client.openapi.model.OrganizationRoleRepresentation;
+import io.phasetwo.service.importexport.representation.KeycloakOrgsRepresentation;
+import io.phasetwo.service.representation.OrganizationRole;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import jakarta.ws.rs.core.Response.Status;
+import java.io.IOException;
+import java.util.List;
+import org.keycloak.admin.client.Keycloak;
+
+public class KeycloakOrgsAdminAPI {
+
+  private static final String ORGS_SEGMENT = "orgs";
+
+  private final String authServerUrl;
+  private final String realm;
+  private final Keycloak adminClient;
+
+  public KeycloakOrgsAdminAPI(String authServerUrl, String realm, Keycloak adminClient) {
+    this.authServerUrl = authServerUrl;
+    this.realm = realm;
+    this.adminClient = adminClient;
+  }
+
+  private RequestSpecification givenSpec() {
+    return given()
+        .baseUri(authServerUrl)
+        .basePath("realms/" + realm + "/" + ORGS_SEGMENT)
+        .contentType("application/json")
+        .auth()
+        .oauth2(adminClient.tokenManager().getAccessTokenString());
+  }
+
+  /** Creates an organization and returns its full representation. */
+  public OrganizationRepresentation createOrganization(OrganizationRepresentation representation)
+      throws JsonProcessingException {
+    Response response =
+        givenSpec().body(toJsonString(representation)).post().andReturn();
+    assertThat(response.getStatusCode(), is(Status.CREATED.getStatusCode()));
+    String loc = response.getHeader("Location");
+    assertNotNull(loc);
+    String id = loc.substring(loc.lastIndexOf("/") + 1);
+    response = givenSpec().get(id).andReturn();
+    assertThat(response.getStatusCode(), is(Status.OK.getStatusCode()));
+    OrganizationRepresentation orgRep =
+        objectMapper().readValue(response.getBody().asString(), OrganizationRepresentation.class);
+    assertThat(orgRep.getId(), is(id));
+    return orgRep;
+  }
+
+  /** Returns the names of all roles defined on an organization. */
+  public List<String> getOrgRoleNames(String orgId) throws JsonProcessingException {
+    Response response = givenSpec().get(orgId + "/roles").andReturn();
+    assertThat(response.getStatusCode(), is(Status.OK.getStatusCode()));
+    List<OrganizationRoleRepresentation> roles =
+        objectMapper()
+            .readValue(
+                response.getBody().asString(),
+                new TypeReference<List<OrganizationRoleRepresentation>>() {});
+    return roles.stream().map(OrganizationRoleRepresentation::getName).toList();
+  }
+
+  public void assertOrgHasRole(String orgId, String roleName) throws JsonProcessingException {
+    List<String> names = getOrgRoleNames(orgId);
+    assertThat(
+        "org " + orgId + " should have role " + roleName, names.contains(roleName), is(true));
+  }
+
+  /** Returns all organizations in the realm. */
+  public List<OrganizationRepresentation> listOrganizations() throws JsonProcessingException {
+    Response response = givenSpec().get().andReturn();
+    assertThat(response.getStatusCode(), is(Status.OK.getStatusCode()));
+      return objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+  }
+
+  /** Returns all roles defined on an organization. */
+  public List<OrganizationRole> getOrgRoles(String orgId) throws JsonProcessingException {
+    Response response = givenSpec().get(orgId + "/roles").andReturn();
+    assertThat(response.getStatusCode(), is(Status.OK.getStatusCode()));
+    return objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+  }
+
+  /** Exports all organizations (with optional member/invitation data). */
+  public KeycloakOrgsRepresentation exportOrgs(boolean exportMembersAndInvitations)
+      throws JsonProcessingException {
+    Response response =
+        givenSpec()
+            .queryParam("exportMembersAndInvitations", exportMembersAndInvitations)
+            .get("export")
+            .andReturn();
+    return objectMapper()
+        .readValue(response.getBody().asString(), KeycloakOrgsRepresentation.class);
+  }
+
+  /** Imports organizations, returning the raw response. */
+  public Response importOrgs(
+      KeycloakOrgsRepresentation representation,
+      boolean skipMissingMember,
+      boolean skipMissingIdp) {
+    return givenSpec()
+        .queryParam("skipMissingMember", skipMissingMember)
+        .queryParam("skipMissingIdp", skipMissingIdp)
+        .body(representation)
+        .post("import")
+        .andReturn();
+  }
+}

--- a/src/test/java/io/phasetwo/service/importexport/OrganizationImportTest.java
+++ b/src/test/java/io/phasetwo/service/importexport/OrganizationImportTest.java
@@ -1,18 +1,16 @@
 package io.phasetwo.service.importexport;
 
 import static io.phasetwo.service.Helpers.loadJson;
-import static io.phasetwo.service.Helpers.objectMapper;
 import static io.phasetwo.service.Orgs.ORG_OWNER_CONFIG_KEY;
-import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.phasetwo.client.openapi.model.OrganizationRepresentation;
 import io.phasetwo.service.AbstractOrganizationTest;
+import io.phasetwo.service.KeycloakOrgsAdminAPI;
 import io.phasetwo.service.importexport.representation.KeycloakOrgsRepresentation;
 import io.phasetwo.service.importexport.representation.OrganizationRoleRepresentation;
 import io.phasetwo.service.representation.OrganizationRole;
@@ -52,23 +50,8 @@ public class OrganizationImportTest extends AbstractOrganizationTest {
         orgsResponse.getStatusCode(), CoreMatchers.is(Response.Status.NO_CONTENT.getStatusCode()));
 
     // validate
-    // get organizations
-    var response =
-        given()
-            .baseUri(container.getAuthServerUrl())
-            .basePath("realms/" + realm + "/orgs")
-            .contentType("application/json")
-            .auth()
-            .oauth2(keycloak.tokenManager().getAccessTokenString())
-            .and()
-            .when()
-            .get()
-            .then()
-            .extract()
-            .response();
-
     List<OrganizationRepresentation> organizations =
-        objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+        new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), realm, keycloak).listOrganizations();
     assertThat(organizations, hasSize(0));
   }
 
@@ -90,23 +73,8 @@ public class OrganizationImportTest extends AbstractOrganizationTest {
     assertThat(orgsResponse.getStatusCode(), CoreMatchers.is(Response.Status.OK.getStatusCode()));
 
     // validate
-    // get organizations
-    var response =
-        given()
-            .baseUri(container.getAuthServerUrl())
-            .basePath("realms/" + realm + "/orgs")
-            .contentType("application/json")
-            .auth()
-            .oauth2(keycloak.tokenManager().getAccessTokenString())
-            .and()
-            .when()
-            .get()
-            .then()
-            .extract()
-            .response();
-
     List<OrganizationRepresentation> organizations =
-        objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+        new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), realm, keycloak).listOrganizations();
     assertThat(organizations, hasSize(3));
 
     // test org1
@@ -195,23 +163,8 @@ public class OrganizationImportTest extends AbstractOrganizationTest {
     assertThat(orgsResponse.getStatusCode(), CoreMatchers.is(Response.Status.OK.getStatusCode()));
 
     // validate
-    // get organizations
-    var response =
-        given()
-            .baseUri(container.getAuthServerUrl())
-            .basePath("realms/" + realm + "/orgs")
-            .contentType("application/json")
-            .auth()
-            .oauth2(keycloak.tokenManager().getAccessTokenString())
-            .and()
-            .when()
-            .get()
-            .then()
-            .extract()
-            .response();
-
     List<OrganizationRepresentation> organizations =
-        objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+        new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), realm, keycloak).listOrganizations();
     assertThat(organizations, hasSize(3));
 
     // test org1
@@ -267,28 +220,14 @@ public class OrganizationImportTest extends AbstractOrganizationTest {
       io.phasetwo.service.importexport.representation.OrganizationRepresentation org,
       OrganizationRepresentation organizationRepresentation,
       String realm) {
-    // roles
-    var rolesResponse =
-        given()
-            .baseUri(container.getAuthServerUrl())
-            .basePath("realms/" + realm + "/orgs/" + organizationRepresentation.getId() + "/roles")
-            .contentType("application/json")
-            .auth()
-            .oauth2(keycloak.tokenManager().getAccessTokenString())
-            .and()
-            .when()
-            .get()
-            .then()
-            .extract()
-            .response();
     try {
       List<OrganizationRole> roles =
-          objectMapper().readValue(rolesResponse.getBody().asString(), new TypeReference<>() {});
+          new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), realm, keycloak)
+              .getOrgRoles(organizationRepresentation.getId());
       assertThat(
           org.getRoles().stream().map(OrganizationRoleRepresentation::getName).toList(),
           containsInAnyOrder(roles.stream().map(OrganizationRole::getName).toArray()));
-
-    } catch (JsonProcessingException e) {
+    } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }

--- a/src/test/java/io/phasetwo/service/importexport/OrganizationInvitationsImportTest.java
+++ b/src/test/java/io/phasetwo/service/importexport/OrganizationInvitationsImportTest.java
@@ -1,16 +1,14 @@
 package io.phasetwo.service.importexport;
 
 import static io.phasetwo.service.Helpers.loadJson;
-import static io.phasetwo.service.Helpers.objectMapper;
-import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.phasetwo.client.openapi.model.OrganizationRepresentation;
 import io.phasetwo.service.AbstractOrganizationTest;
+import io.phasetwo.service.KeycloakOrgsAdminAPI;
 import io.phasetwo.service.importexport.representation.KeycloakOrgsRepresentation;
 import io.phasetwo.service.representation.Invitation;
 import jakarta.ws.rs.core.Response;
@@ -48,23 +46,8 @@ public class OrganizationInvitationsImportTest extends AbstractOrganizationTest 
     assertThat(orgsImportResponse.getStatusCode(), is(Response.Status.OK.getStatusCode()));
 
     // validate
-    // get organizations
-    var response =
-        given()
-            .baseUri(container.getAuthServerUrl())
-            .basePath("realms/" + realm + "/orgs")
-            .contentType("application/json")
-            .auth()
-            .oauth2(keycloak.tokenManager().getAccessTokenString())
-            .and()
-            .when()
-            .get()
-            .then()
-            .extract()
-            .response();
-
     List<OrganizationRepresentation> organizations =
-        objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+        new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), realm, keycloak).listOrganizations();
     assertThat(organizations, hasSize(2));
 
     // test org1
@@ -174,23 +157,8 @@ public class OrganizationInvitationsImportTest extends AbstractOrganizationTest 
     assertThat(orgImportResponse.getStatusCode(), is(Response.Status.OK.getStatusCode()));
 
     // validate
-    // get organizations
-    var response =
-        given()
-            .baseUri(container.getAuthServerUrl())
-            .basePath("realms/" + realm + "/orgs")
-            .contentType("application/json")
-            .auth()
-            .oauth2(keycloak.tokenManager().getAccessTokenString())
-            .and()
-            .when()
-            .get()
-            .then()
-            .extract()
-            .response();
-
     List<OrganizationRepresentation> organizations =
-        objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+        new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), realm, keycloak).listOrganizations();
     assertThat(organizations, hasSize(1));
 
     // test org1
@@ -257,23 +225,8 @@ public class OrganizationInvitationsImportTest extends AbstractOrganizationTest 
     assertThat(orgImportResponse.getStatusCode(), is(Response.Status.OK.getStatusCode()));
 
     // validate
-    // get organizations
-    var response =
-        given()
-            .baseUri(container.getAuthServerUrl())
-            .basePath("realms/" + realm + "/orgs")
-            .contentType("application/json")
-            .auth()
-            .oauth2(keycloak.tokenManager().getAccessTokenString())
-            .and()
-            .when()
-            .get()
-            .then()
-            .extract()
-            .response();
-
     List<OrganizationRepresentation> organizations =
-        objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+        new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), realm, keycloak).listOrganizations();
     assertThat(organizations, hasSize(2));
 
     // test org1

--- a/src/test/java/io/phasetwo/service/importexport/OrganizationMembersImportTest.java
+++ b/src/test/java/io/phasetwo/service/importexport/OrganizationMembersImportTest.java
@@ -1,16 +1,14 @@
 package io.phasetwo.service.importexport;
 
 import static io.phasetwo.service.Helpers.loadJson;
-import static io.phasetwo.service.Helpers.objectMapper;
-import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.phasetwo.client.openapi.model.OrganizationRepresentation;
 import io.phasetwo.service.AbstractOrganizationTest;
+import io.phasetwo.service.KeycloakOrgsAdminAPI;
 import io.phasetwo.service.importexport.representation.KeycloakOrgsRepresentation;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
@@ -46,23 +44,8 @@ public class OrganizationMembersImportTest extends AbstractOrganizationTest {
     assertThat(importRealmResponse.getStatusCode(), is(Response.Status.OK.getStatusCode()));
 
     // validate
-    // get organizations
-    var response =
-        given()
-            .baseUri(container.getAuthServerUrl())
-            .basePath("realms/" + realm + "/orgs")
-            .contentType("application/json")
-            .auth()
-            .oauth2(keycloak.tokenManager().getAccessTokenString())
-            .and()
-            .when()
-            .get()
-            .then()
-            .extract()
-            .response();
-
     List<OrganizationRepresentation> organizations =
-        objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+        new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), realm, keycloak).listOrganizations();
     assertThat(organizations, hasSize(2));
 
     // test org1
@@ -148,23 +131,8 @@ public class OrganizationMembersImportTest extends AbstractOrganizationTest {
     assertThat(orgResponse.getStatusCode(), is(Response.Status.OK.getStatusCode()));
 
     // validate
-    // get organizations
-    var response =
-        given()
-            .baseUri(container.getAuthServerUrl())
-            .basePath("realms/" + realm + "/orgs")
-            .contentType("application/json")
-            .auth()
-            .oauth2(keycloak.tokenManager().getAccessTokenString())
-            .and()
-            .when()
-            .get()
-            .then()
-            .extract()
-            .response();
-
     List<OrganizationRepresentation> organizations =
-        objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+        new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), realm, keycloak).listOrganizations();
     assertThat(organizations, hasSize(1));
 
     // test org1

--- a/src/test/java/io/phasetwo/service/importexport/OrganizationTransactionalImportTest.java
+++ b/src/test/java/io/phasetwo/service/importexport/OrganizationTransactionalImportTest.java
@@ -1,19 +1,17 @@
 package io.phasetwo.service.importexport;
 
 import static io.phasetwo.service.Helpers.loadJson;
-import static io.phasetwo.service.Helpers.objectMapper;
-import static io.phasetwo.service.Helpers.toJsonString;
-import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.phasetwo.client.openapi.model.OrganizationRepresentation;
 import io.phasetwo.service.AbstractOrganizationTest;
+import io.phasetwo.service.KeycloakOrgsAdminAPI;
 import io.phasetwo.service.importexport.representation.KeycloakOrgsRepresentation;
 import jakarta.ws.rs.core.Response;
+import java.io.IOException;
 import java.util.List;
 import lombok.extern.jbosslog.JBossLog;
 import org.hamcrest.CoreMatchers;
@@ -35,20 +33,8 @@ public class OrganizationTransactionalImportTest extends AbstractOrganizationTes
     importRealm(testRealm, keycloak);
 
     // create second organization which exists in the import json
-    var organizationRepresentation = new OrganizationRepresentation().name("test3");
-    var createOrgResponse =
-        given()
-            .baseUri(container.getAuthServerUrl())
-            .basePath("realms/" + realm + "/orgs")
-            .contentType("application/json")
-            .auth()
-            .oauth2(keycloak.tokenManager().getAccessTokenString())
-            .body(toJsonString(organizationRepresentation))
-            .when()
-            .post()
-            .andReturn();
-
-    assertThat(createOrgResponse.getStatusCode(), is(Response.Status.CREATED.getStatusCode()));
+    new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), realm, keycloak)
+        .createOrganization(new OrganizationRepresentation().name("test3"));
 
     // prepare data
     KeycloakOrgsRepresentation orgsRepresentation =
@@ -60,23 +46,8 @@ public class OrganizationTransactionalImportTest extends AbstractOrganizationTes
         orgsResponse.getStatusCode(), CoreMatchers.is(Response.Status.CONFLICT.getStatusCode()));
 
     // validate
-    // get organizations
-    var response =
-        given()
-            .baseUri(container.getAuthServerUrl())
-            .basePath("realms/" + realm + "/orgs")
-            .contentType("application/json")
-            .auth()
-            .oauth2(keycloak.tokenManager().getAccessTokenString())
-            .and()
-            .when()
-            .get()
-            .then()
-            .extract()
-            .response();
-
     List<OrganizationRepresentation> organizations =
-        objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+        new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), realm, keycloak).listOrganizations();
     assertThat(organizations, hasSize(1));
   }
 

--- a/src/test/java/io/phasetwo/service/resource/InitRolesPostMigrationTest.java
+++ b/src/test/java/io/phasetwo/service/resource/InitRolesPostMigrationTest.java
@@ -1,0 +1,253 @@
+package io.phasetwo.service.resource;
+
+import static io.phasetwo.service.resource.OrganizationAdminAuth.ORG_ROLE_DELETE_ORGANIZATION;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.phasetwo.client.openapi.model.OrganizationRepresentation;
+import io.phasetwo.service.KeycloakOrgsAdminAPI;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.jbosslog.JBossLog;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.keycloak.admin.client.Keycloak;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.utility.MountableFile;
+
+@JBossLog
+@EnabledIfSystemProperty(named = "include.cypress", matches = "true")
+public class InitRolesPostMigrationTest {
+
+  static final String KEYCLOAK_IMAGE =
+      String.format(
+          "quay.io/phasetwo/keycloak-crdb:%s", System.getProperty("keycloak-version", "26.5.7"));
+  static final String REALM = "master";
+  static final String ADMIN_CLI = "admin-cli";
+
+  static final String[] deps = {
+    "dnsjava:dnsjava",
+    "org.wildfly.client:wildfly-client-config",
+    "org.jboss.resteasy:resteasy-client",
+    "org.jboss.resteasy:resteasy-client-api",
+    "org.keycloak:keycloak-admin-client",
+    "io.phasetwo.keycloak:keycloak-events"
+  };
+
+  static List<File> getDeps() {
+    List<File> dependencies = new ArrayList<>();
+    for (String dep : deps) {
+      dependencies.addAll(getDep(dep));
+    }
+    return dependencies;
+  }
+
+  static List<File> getDep(String pkg) {
+    return Maven.resolver()
+        .loadPomFromFile("./pom.xml")
+        .resolve(pkg)
+        .withoutTransitivity()
+        .asList(File.class);
+  }
+
+  static Network network;
+  static PostgreSQLContainer<?> postgres;
+  static KeycloakContainer keycloak;
+  static Keycloak adminClient;
+
+  @BeforeAll
+  static void setUp() {
+    network = Network.newNetwork();
+
+    postgres =
+        new PostgreSQLContainer<>("postgres:17")
+            .withNetwork(network)
+            .withNetworkAliases("postgres")
+            .withDatabaseName("keycloak")
+            .withUsername("keycloak")
+            .withPassword("keycloak");
+    postgres.start();
+
+    keycloak = buildKeycloakContainer();
+    keycloak.start();
+
+    adminClient = buildAdminClient();
+  }
+
+  @AfterAll
+  static void tearDown() throws IOException {
+    if (keycloak != null) stopKeycloak(keycloak);
+    if (postgres != null) postgres.stop();
+    if (network != null) network.close();
+  }
+
+  private static boolean isJacocoPresent() {
+    return Files.exists(Path.of("target/jacoco-agent/org.jacoco.agent-runtime.jar"));
+  }
+
+  private static KeycloakContainer buildKeycloakContainer() {
+    KeycloakContainer kc =
+        new KeycloakContainer(KEYCLOAK_IMAGE)
+            .withNetwork(network)
+            .withContextPath("/auth")
+            .withImagePullPolicy(PullPolicy.alwaysPull())
+            .withProviderClassesFrom("target/classes")
+            .withProviderLibsFrom(getDeps())
+            .withEnv("KC_DB", "postgres")
+            .withEnv("KC_DB_URL", "jdbc:postgresql://postgres:5432/keycloak")
+            .withEnv("KC_DB_USERNAME", "keycloak")
+            .withEnv("KC_DB_PASSWORD", "keycloak");
+    if (isJacocoPresent()) {
+      kc =
+          kc.withCopyFileToContainer(
+                  MountableFile.forHostPath("target/jacoco-agent/"), "/jacoco-agent")
+              .withEnv(
+                  "JAVA_OPTS",
+                  "-XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m"
+                      + " -javaagent:/jacoco-agent/org.jacoco.agent-runtime.jar=destfile=/tmp/jacoco.exec");
+    } else {
+      kc = kc.withEnv("JAVA_OPTS", "-XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m");
+    }
+    return kc;
+  }
+
+  private static Keycloak buildAdminClient() {
+    return Keycloak.getInstance(
+        keycloak.getAuthServerUrl(),
+        REALM,
+        keycloak.getAdminUsername(),
+        keycloak.getAdminPassword(),
+        ADMIN_CLI);
+  }
+
+  // Gracefully stops the container so the JVM flushes Jacoco data, then extracts the report.
+  // Each container gets its own .exec file (keyed by short container ID); the maven jacoco:merge
+  // goal combines all .exec files in target/jacoco-report/ into a single report.
+  private static void stopKeycloak(KeycloakContainer kc) throws IOException {
+    if (isJacocoPresent()) {
+      String containerId = kc.getContainerId();
+      String shortId = containerId.length() > 12 ? containerId.substring(0, 12) : containerId;
+      kc.getDockerClient().stopContainerCmd(containerId).exec();
+      Files.createDirectories(Path.of("target", "jacoco-report"));
+      kc.copyFileFromContainer(
+          "/tmp/jacoco.exec", "./target/jacoco-report/jacoco-%s.exec".formatted(shortId));
+    }
+    kc.stop();
+  }
+
+  private static void restartKeycloak() throws IOException {
+    stopKeycloak(keycloak);
+    keycloak = buildKeycloakContainer();
+    keycloak.start();
+    adminClient = buildAdminClient();
+  }
+
+  private KeycloakOrgsAdminAPI orgsApi() {
+    return new KeycloakOrgsAdminAPI(keycloak.getAuthServerUrl(), REALM, adminClient);
+  }
+
+  @Test
+  void testUpdateExistingOrganizationsWithNewRoles() throws Exception {
+    int orgCount = 3;
+    List<String> orgIds = new ArrayList<>();
+    for (int i = 0; i < orgCount; i++) {
+      OrganizationRepresentation org =
+          orgsApi()
+              .createOrganization(
+                  new OrganizationRepresentation().name("migration-test-org-" + i));
+      orgIds.add(org.getId());
+    }
+
+    // Organizations get delete-organization by default (added since PR #331)
+    for (String orgId : orgIds) {
+      orgsApi().assertOrgHasRole(orgId, ORG_ROLE_DELETE_ORGANIZATION);
+    }
+
+    // The REST API protects default roles from deletion, so we remove the role
+    // directly from the DB to simulate organizations that existed before PR #331
+    deleteOrgRoleFromDb(orgIds, ORG_ROLE_DELETE_ORGANIZATION);
+    assertDbRoleCount(orgIds, ORG_ROLE_DELETE_ORGANIZATION, 0);
+
+    // Restart triggers PostMigrationEvent → initRoles → updateExistingOrganizationsWithNewRoles
+    restartKeycloak();
+
+    assertDbRoleCount(orgIds, ORG_ROLE_DELETE_ORGANIZATION, orgCount);
+    for (String orgId : orgIds) {
+      orgsApi().assertOrgHasRole(orgId, ORG_ROLE_DELETE_ORGANIZATION);
+    }
+
+    // Second restart verifies idempotency — no duplicate roles
+    restartKeycloak();
+    assertDbRoleCount(orgIds, ORG_ROLE_DELETE_ORGANIZATION, orgCount);
+  }
+
+  private void deleteOrgRoleFromDb(List<String> orgIds, String roleName) throws SQLException {
+    String placeholders = orgIds.stream().map(id -> "?").reduce((a, b) -> a + "," + b).orElse("?");
+    // user_organization_role_mapping has a FK to organization_role, so delete child rows first
+    String deleteMappings =
+        ("DELETE FROM user_organization_role_mapping WHERE role_id IN "
+                + "(SELECT id FROM organization_role WHERE name = ? AND organization_id IN (%s))")
+            .formatted(placeholders);
+    String deleteRoles =
+        "DELETE FROM organization_role WHERE name = ? AND organization_id IN (" + placeholders + ")";
+    try (Connection conn =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())) {
+      try (PreparedStatement ps = conn.prepareStatement(deleteMappings)) {
+        ps.setString(1, roleName);
+        for (int i = 0; i < orgIds.size(); i++) {
+          ps.setString(i + 2, orgIds.get(i));
+        }
+        ps.executeUpdate();
+      }
+      try (PreparedStatement ps = conn.prepareStatement(deleteRoles)) {
+        ps.setString(1, roleName);
+        for (int i = 0; i < orgIds.size(); i++) {
+          ps.setString(i + 2, orgIds.get(i));
+        }
+        int deleted = ps.executeUpdate();
+        assertThat("should have deleted one row per org", deleted, is(orgIds.size()));
+      }
+    }
+  }
+
+  private void assertDbRoleCount(List<String> orgIds, String roleName, int expectedCount)
+      throws SQLException {
+    String placeholders = orgIds.stream().map(id -> "?").reduce((a, b) -> a + "," + b).orElse("?");
+    String sql =
+        "SELECT COUNT(*) FROM organization_role WHERE name = ? AND organization_id IN ("
+            + placeholders
+            + ")";
+    try (Connection conn =
+            DriverManager.getConnection(
+                postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+        PreparedStatement ps = conn.prepareStatement(sql)) {
+      ps.setString(1, roleName);
+      for (int i = 0; i < orgIds.size(); i++) {
+        ps.setString(i + 2, orgIds.get(i));
+      }
+      try (ResultSet rs = ps.executeQuery()) {
+        rs.next();
+        assertThat(
+            "DB count of role '" + roleName + "' for given orgs",
+            rs.getInt(1),
+            is(expectedCount));
+      }
+    }
+  }
+}

--- a/src/test/java/io/phasetwo/service/resource/InitRolesPostMigrationTest.java
+++ b/src/test/java/io/phasetwo/service/resource/InitRolesPostMigrationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.RealmRepresentation;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.images.PullPolicy;
@@ -161,6 +162,37 @@ public class InitRolesPostMigrationTest {
     return new KeycloakOrgsAdminAPI(keycloak.getAuthServerUrl(), REALM, adminClient);
   }
 
+  private KeycloakOrgsAdminAPI orgsApi(String realm) {
+    return new KeycloakOrgsAdminAPI(keycloak.getAuthServerUrl(), realm, adminClient);
+  }
+
+  private static void restartKeycloakWithBatchSize(int batchSize) throws IOException {
+    stopKeycloak(keycloak);
+    keycloak =
+        buildKeycloakContainer()
+            .withEnv("KC_ORGS_MIGRATION_BATCH_SIZE", String.valueOf(batchSize));
+    keycloak.start();
+    adminClient = buildAdminClient();
+  }
+
+  private List<String> createOrgsInRealm(String realm, int count) throws IOException {
+    List<String> ids = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      OrganizationRepresentation org =
+          orgsApi(realm)
+              .createOrganization(new OrganizationRepresentation().name("test-org-" + i));
+      ids.add(org.getId());
+    }
+    return ids;
+  }
+
+  private void assertAllOrgsHaveRole(String realm, List<String> orgIds, String roleName)
+      throws IOException {
+    for (String orgId : orgIds) {
+      orgsApi(realm).assertOrgHasRole(orgId, roleName);
+    }
+  }
+
   @Test
   void testUpdateExistingOrganizationsWithNewRoles() throws Exception {
     int orgCount = 3;
@@ -194,6 +226,54 @@ public class InitRolesPostMigrationTest {
     // Second restart verifies idempotency — no duplicate roles
     restartKeycloak();
     assertDbRoleCount(orgIds, ORG_ROLE_DELETE_ORGANIZATION, orgCount);
+  }
+
+  @Test
+  void testMultiRealmMigrationWithBatching() throws Exception {
+    // Create 3 additional realms alongside master
+    String realmA = "migration-realm-a";
+    String realmB = "migration-realm-b";
+    String realmC = "migration-realm-c";
+    for (String realm : List.of(realmA, realmB, realmC)) {
+      RealmRepresentation rep = new RealmRepresentation();
+      rep.setRealm(realm);
+      rep.setEnabled(true);
+      adminClient.realms().create(rep);
+    }
+
+    // Create 12+15+16+23 = 66 orgs spread across 4 realms
+    List<String> masterOrgIds = createOrgsInRealm(REALM, 12);
+    List<String> realmAOrgIds = createOrgsInRealm(realmA, 15);
+    List<String> realmBOrgIds = createOrgsInRealm(realmB, 16);
+    List<String> realmCOrgIds = createOrgsInRealm(realmC, 23);
+
+    List<String> allOrgIds = new ArrayList<>();
+    allOrgIds.addAll(masterOrgIds);
+    allOrgIds.addAll(realmAOrgIds);
+    allOrgIds.addAll(realmBOrgIds);
+    allOrgIds.addAll(realmCOrgIds);
+    int totalOrgs = allOrgIds.size(); // 66
+
+    // All orgs get delete-organization by default
+    assertDbRoleCount(allOrgIds, ORG_ROLE_DELETE_ORGANIZATION, totalOrgs);
+
+    // Strip the role via JDBC to simulate pre-PR#331 state across all realms
+    deleteOrgRoleFromDb(allOrgIds, ORG_ROLE_DELETE_ORGANIZATION);
+    assertDbRoleCount(allOrgIds, ORG_ROLE_DELETE_ORGANIZATION, 0);
+
+    // Restart with batch size 6 — 66 orgs require ceil(66/6)=11 batches
+    restartKeycloakWithBatchSize(6);
+
+    // All 66 orgs should have the role restored, across all 4 realms
+    assertDbRoleCount(allOrgIds, ORG_ROLE_DELETE_ORGANIZATION, totalOrgs);
+    assertAllOrgsHaveRole(REALM, masterOrgIds, ORG_ROLE_DELETE_ORGANIZATION);
+    assertAllOrgsHaveRole(realmA, realmAOrgIds, ORG_ROLE_DELETE_ORGANIZATION);
+    assertAllOrgsHaveRole(realmB, realmBOrgIds, ORG_ROLE_DELETE_ORGANIZATION);
+    assertAllOrgsHaveRole(realmC, realmCOrgIds, ORG_ROLE_DELETE_ORGANIZATION);
+
+    // Second restart: idempotency — no duplicate roles should be created
+    restartKeycloakWithBatchSize(6);
+    assertDbRoleCount(allOrgIds, ORG_ROLE_DELETE_ORGANIZATION, totalOrgs);
   }
 
   private void deleteOrgRoleFromDb(List<String> orgIds, String roleName) throws SQLException {

--- a/src/test/java/io/phasetwo/web/AbstractCypressOrganizationTest.java
+++ b/src/test/java/io/phasetwo/web/AbstractCypressOrganizationTest.java
@@ -21,6 +21,7 @@ import io.github.wimdeblauwe.testcontainers.cypress.CypressTest;
 import io.github.wimdeblauwe.testcontainers.cypress.CypressTestResults;
 import io.github.wimdeblauwe.testcontainers.cypress.CypressTestSuite;
 import io.phasetwo.client.openapi.model.OrganizationRepresentation;
+import io.phasetwo.service.KeycloakOrgsAdminAPI;
 import io.phasetwo.service.resource.OrganizationResourceProviderFactory;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
@@ -195,23 +196,10 @@ public class AbstractCypressOrganizationTest {
     return createOrganization(keycloak, representation);
   }
 
-  // create an organization, fet the created organization and returns it
   protected OrganizationRepresentation createOrganization(
       Keycloak keycloak, OrganizationRepresentation representation) throws IOException {
-    Response response =
-        givenSpec(keycloak).and().body(toJsonString(representation)).when().post().andReturn();
-
-    assertThat(response.getStatusCode(), is(Status.CREATED.getStatusCode()));
-    assertNotNull(response.getHeader("Location"));
-    String loc = response.getHeader("Location");
-    String id = loc.substring(loc.lastIndexOf("/") + 1);
-
-    response = getRequest(id);
-    assertThat(response.statusCode(), Matchers.is(Status.OK.getStatusCode()));
-    OrganizationRepresentation orgRep =
-        objectMapper().readValue(response.getBody().asString(), OrganizationRepresentation.class);
-    assertThat(orgRep.getId(), is(id));
-    return orgRep;
+    return new KeycloakOrgsAdminAPI(container.getAuthServerUrl(), REALM, keycloak)
+        .createOrganization(representation);
   }
 
   protected RequestSpecification givenSpec(Keycloak keycloak, String... paths) {


### PR DESCRIPTION
**Problem**

On every Keycloak startup, `initRoles` streamed all organizations across all realms and checked each one individually for the presence of the `delete-organization` role. On instances with a large number of
organizations this caused transaction timeouts, leaving the migration incomplete with no way to recover without skipping it entirely (`KC_ORGS_SKIP_MIGRATION`).

**Changes**

The first commit introduced `KeycloakOrgsAdminAPI` and `InitRolesPostMigrationTest` as test coverage for the existing (unoptimized) code paths; the second commit contains the actual optimization.

`KeycloakOrgsAdminAPI` - new test utility class that consolidates the duplicated RestAssured boilerplate (`createOrganization`, `listOrganizations`, `getOrgRoles`, `exportOrgs`, `importOrgs`) that was copy-pasted across `AbstractOrganizationTest`, `AbstractCypressOrganizationTest`, and all import test classes.

Migration optimization - replaces the per-org ORM check with a JPQL `NamedQuery` (`getOrganizationsMissingRole`) that pushes filtering to the DB, returning only organizations actually missing the role across all realms. Two concrete gains:
- Results are processed in separate transactions per batch (`KC_ORGS_MIGRATION_BATCH_SIZE`, default 500), so a timeout no longer aborts the whole migration - subsequent restarts pick up where the last one left off.
- Filtering happens in the DB rather than in application code, eliminating the N+1 check pattern.
- Batch results are grouped by `realmId` in Java before calling `org.addRole()` through the existing model layer, keeping the insertion path consistent with how it worked before.

`InitRolesPostMigrationTest` - new integration test that spins up a PostgreSQL container alongside Keycloak, strips roles directly via JDBC to simulate the pre-#331 state, and verifies both correctness and idempotency. Includes a multi-realm scenario (4 realms, 66 orgs total) with a batch size of 6 to exercise the batching logic across multiple transactions and realm boundaries.