### PR TITLE
Add composite index on ORGANIZATION_ATTRIBUTE (NAME, VALUE) and remov…

### DIFF
--- a/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java
+++ b/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java
@@ -318,8 +318,8 @@ public class JpaOrganizationProvider implements OrganizationProvider {
 
         attributePredicates.add(
             builder.and(
-                builder.equal(builder.lower(attributesJoin.get("name")), key.toLowerCase()),
-                builder.equal(builder.lower(attributesJoin.get("value")), value.toLowerCase())));
+                builder.equal(attributesJoin.get("name"), key),
+                builder.equal(attributesJoin.get("value"), value)));
       }
     }
 

--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-20260421.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-20260421.xml
@@ -1,0 +1,16 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="phasetwo" id="add-organization-attribute-name-value-index">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="IDX_ORG_ATTR_NAME_VALUE"/>
+            </not>
+        </preConditions>
+        <createIndex indexName="IDX_ORG_ATTR_NAME_VALUE" tableName="ORGANIZATION_ATTRIBUTE">
+            <column name="NAME"/>
+            <column name="VALUE"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-master.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-master.xml
@@ -26,5 +26,6 @@
   <include file="META-INF/jpa-changelog-phasetwo-20240611.xml"/>
   <include file="META-INF/jpa-changelog-phasetwo-20250512.xml"/>
   <include file="META-INF/jpa-changelog-phasetwo-20241228.xml"/>
+  <include file="META-INF/jpa-changelog-phasetwo-20260421.xml"/>
 
 </databaseChangeLog>

--- a/src/test/java/io/phasetwo/service/resource/OrganizationResourceTest.java
+++ b/src/test/java/io/phasetwo/service/resource/OrganizationResourceTest.java
@@ -268,6 +268,17 @@ class OrganizationResourceTest extends AbstractOrganizationTest {
     assertThat(orgs, notNullValue());
     assertThat(orgs, hasSize(2));
 
+    // attribute search is case-sensitive
+    response = givenSpec().when().queryParam("q", "FOO:bar").get().andReturn();
+    assertThat(response.statusCode(), is(Status.OK.getStatusCode()));
+    orgs = objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+    assertThat(orgs, hasSize(0));
+
+    response = givenSpec().when().queryParam("q", "foo:BAR").get().andReturn();
+    assertThat(response.statusCode(), is(Status.OK.getStatusCode()));
+    orgs = objectMapper().readValue(response.getBody().asString(), new TypeReference<>() {});
+    assertThat(orgs, hasSize(0));
+
     // Search attributes and name
     response =
         givenSpec().when().queryParam("search", "qu").queryParam("q", "foo:bar").get().andReturn();


### PR DESCRIPTION
…e LOWER() from attribute search predicates

Attribute search via the q parameter was doing a full table scan of ORGANIZATION_ATTRIBUTE with LOWER() on both columns, defeating any index. The LOWER() is inconsistent with how attributes are stored and queried elsewhere (named queries use exact matching). Removing it and adding a composite index on (NAME, VALUE) allows the DB to seek directly to matching rows, making attribute-based org search viable at scale.