### PR TITLE
Fix flaky Cypress tests failing with KeyboardEvent undefined

### DIFF
--- a/src/test/e2e/cypress/e2e/home-idp-organization/user-attribute-based-idp.cy.ts
+++ b/src/test/e2e/cypress/e2e/home-idp-organization/user-attribute-based-idp.cy.ts
@@ -27,8 +27,8 @@ describe('user login via home idp provider', () => {
         cy.get('#username').type(idpUser.email);
         cy.get('#kc-login').click();
         cy.url().should('contain', 'external-idp');
-        cy.get('#username').type(idpUser.username);
-        cy.get('#password').type(idpUser.password);
+        cy.get('#username').should('be.visible').type(idpUser.username);
+        cy.get('#password').should('be.visible').type(idpUser.password);
         cy.get('#kc-login').click();
 
         cy.url().should('contain', 'test-realm');
@@ -50,8 +50,8 @@ describe('user login via home idp provider', () => {
         cy.get('#username').type(idpUser.email);
         cy.get('#kc-login').click();
         cy.url().should('contain', 'external-idp');
-        cy.get('#username').type(idpUser.username);
-        cy.get('#password').type(idpUser.password);
+        cy.get('#username').should('be.visible').type(idpUser.username);
+        cy.get('#password').should('be.visible').type(idpUser.password);
         cy.get('#kc-login').click();
         cy.url().should('contain', 'test-realm');
         cy.contains('Personal');

--- a/src/test/e2e/cypress/e2e/home-idp-organization/user-without-org-links-account.cy.ts
+++ b/src/test/e2e/cypress/e2e/home-idp-organization/user-without-org-links-account.cy.ts
@@ -25,8 +25,8 @@ describe('Organiationless IDP Linked user login', () => {
 
         cy.url().should('contain', 'external-idp');
 
-        cy.get('#username').type(organizationlessAuthItUser.username, {force: true});
-        cy.get('#password').type(organizationlessAuthItUser.password, {force: true});
+        cy.get('#username').should('be.visible').type(organizationlessAuthItUser.username, {force: true});
+        cy.get('#password').should('be.visible').type(organizationlessAuthItUser.password, {force: true});
         cy.get('#kc-login').click();
 
         cy.url().should('contain', 'test-realm/account');


### PR DESCRIPTION
Add `.should('be.visible')` before `.type()` calls that execute immediately after navigating to the external-idp login page. This gives Cypress time to wait until the page's window context is fully initialized before keyboard simulation runs, preventing the intermittent `TypeError: Cannot read properties of undefined (reading 'KeyboardEvent')`.

Refs #447