### PR TITLE
Add some extra logging to the cypress tests.

### DIFF
--- a/src/test/e2e/cypress.config.ts
+++ b/src/test/e2e/cypress.config.ts
@@ -6,6 +6,14 @@ export default defineConfig({
     reporter: 'cypress-multi-reporters',
     reporterOptions: {
       configFile: 'reporter-config.json'
-    }
+    },
+    setupNodeEvents(on) {
+      on('task', {
+        log(message) {
+          console.log(message)
+          return null
+        },
+      })
+    },
   },
 });

--- a/src/test/e2e/cypress/e2e/home-idp-organization/user-without-org-links-account.cy.ts
+++ b/src/test/e2e/cypress/e2e/home-idp-organization/user-without-org-links-account.cy.ts
@@ -5,20 +5,26 @@ describe('Organiationless IDP Linked user login', () => {
     // using force: true, cause flakyness https://github.com/cypress-io/cypress/issues/5830
     it('a user registers their own idp & logs in with that', () => {
         cy.visit(testRealmLoginUri);
+        cy.task('log', `Visited the login URL 1st time`)
         cy.get('#username').type(organizationlessAuthItUser.username, {force: true});
+        cy.task('log', `Username typed in`)
         cy.get('#kc-login').click();
         cy.get('#password').type(organizationlessAuthItUser.password, {force: true});
+        cy.task('log', `Password typed in`)
         cy.get('#kc-login').click();
         cy.contains('Personal');
         cy.get("#nav-toggle").click();
+        cy.task('log', `Nav-toggle clicked`)
 
         cy.get('[data-testid="accountSecurity"]').click();
         cy.get('[data-testid="account-security/linked-accounts"]').click();
+        cy.task('log', `Navigated to linked accounts page`)
         cy.url().should('contain', 'account-security/linked-accounts');
 
         cy.get('[data-testid="linked-accounts/oidc-idp"]')
             .find('button')
             .click()
+        cy.task('log', `OIDC-IDP linking initiated, button clicked`)
 
         cy.contains('Linking oidc-idp')
         cy.get('#kc-continue').click();
@@ -26,7 +32,9 @@ describe('Organiationless IDP Linked user login', () => {
         cy.url().should('contain', 'external-idp');
 
         cy.get('#username').should('be.visible').type(organizationlessAuthItUser.username, {force: true});
+        cy.task('log', `external-idp username typed in`)
         cy.get('#password').should('be.visible').type(organizationlessAuthItUser.password, {force: true});
+        cy.task('log', `external-idp password typed in`)
         cy.get('#kc-login').click();
 
         cy.url().should('contain', 'test-realm/account');
@@ -39,7 +47,9 @@ describe('Organiationless IDP Linked user login', () => {
         cy.clearCookies()
 
         cy.visit(testRealmLoginUri);
+        cy.task('log', `Verifying user can log in with external IDP`)
         cy.get('#username').type(organizationlessAuthItUser.username, {force: true});
+        cy.task('log', `Username typed in`)
         cy.get('#kc-login').click();
         // after linking the account to the user on the next log-in we are automatically redirected to the external idp's login page
         cy.url().should('contain', 'external-idp');


### PR DESCRIPTION
This test seems to be flaky, see build failure: https://github.com/p2-inc/keycloak-orgs/actions/runs/25101952378/attempts/2

#448 tried to resolve this, but still fails. Adding some extra logging, so we knew which typing fails next time.