### PR TITLE
Add database-compatibility smoke tests for PostgreSQL, MySQL, and MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ If you are using the extension as bundled in the [Docker image](https://quay.io/
 
 Although it has been developed and working since Keycloak 9.0.0, the extensions are currently known to work with Keycloak > 17.0.0. Other versions may work also. Additionally, because of the fast pace of breaking changes since Keycloak "X" (Quarkus version), we don't make any guaranteed that this will work with any version other than it is packaged with in the [Docker image](https://quay.io/repository/phasetwo/phasetwo-keycloak).
 
+We officially support CockroachDB, PostgreSQL, and MySQL. We welcome PRs that add compatibility with other databases.
+
+The following database versions are covered by CI smoke tests on every push:
+
+| Database   | Version tested |
+|------------|---------------|
+| PostgreSQL | 18            |
+| MySQL      | 8.4           |
+| MariaDB    | 11.8          |
+
+CockroachDB is tested manually rather than in CI: DDL operations (including Keycloak's schema startup) can take a long time in CockroachDB and are difficult to run reliably in an automated pipeline.
+
+If you are opening a PR that adds or restores compatibility with a database, please include a corresponding test that extends [`AbstractDbCompatibilityTest`](src/test/java/io/phasetwo/service/resource/AbstractDbCompatibilityTest.java) — see the existing [`MySQLCompatibilityTest`](src/test/java/io/phasetwo/service/resource/MySQLCompatibilityTest.java), [`MariaDBCompatibilityTest`](src/test/java/io/phasetwo/service/resource/MariaDBCompatibilityTest.java), and [`PostgreSQLCompatibilityTest`](src/test/java/io/phasetwo/service/resource/PostgreSQLCompatibilityTest.java) for reference.
+
 ## Extensions
 
 ### Data

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,24 @@
       </properties>
       <build>
         <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>warn-cypress-tests-deprecated</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <echo level="warn" message="[DEPRECATED] The cypress-tests profile is deprecated. Please use -Pintegration-tests instead, which runs Cypress and the database-compatibility smoke tests."/>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
           <!--   copy the jacoco agent to target build  -->
           <plugin>
             <artifactId>maven-dependency-plugin</artifactId>
@@ -80,6 +98,76 @@
           </plugin>
 
           <!--   set up jacoco plugin to generate report  -->
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${jacoco.version}</version>
+            <executions>
+              <execution>
+                <id>merge</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>merge</goal>
+                </goals>
+                <configuration>
+                  <fileSets>
+                    <fileSet>
+                      <directory>${project.build.directory}/jacoco-report/</directory>
+                      <includes>
+                        <include>*.exec</include>
+                      </includes>
+                    </fileSet>
+                  </fileSets>
+                  <destFile>${project.build.directory}/jacoco-report/jacoco-all.exec</destFile>
+                </configuration>
+              </execution>
+              <execution>
+                <id>report</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+                <configuration>
+                  <dataFile>${project.build.directory}/jacoco-report/jacoco-all.exec</dataFile>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- integration-tests activates both the Cypress E2E suite and the
+         MySQL/MariaDB database-compatibility smoke tests. The cypress-tests
+         profile is intentionally kept for backwards compatibility: any
+         external scripts, local workflows, or documentation that reference
+         -Pcypress-tests will continue to work unchanged. CI uses
+         -Pintegration-tests so the full suite runs on every push/PR. -->
+    <profile>
+      <id>integration-tests</id>
+      <properties>
+        <include.cypress>true</include.cypress>
+        <include.integration>true</include.integration>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-jacoco</id>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <phase>compile</phase>
+                <configuration>
+                  <includeArtifactIds>org.jacoco.agent</includeArtifactIds>
+                  <includeClassifiers>runtime</includeClassifiers>
+                  <outputDirectory>${project.build.directory}/jacoco-agent</outputDirectory>
+                  <stripVersion>true</stripVersion>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
@@ -215,6 +303,7 @@
           <systemPropertyVariables>
             <keycloak-version>${keycloak.version}</keycloak-version>
             <include.cypress>${include.cypress}</include.cypress>
+            <include.integration>${include.integration}</include.integration>
           </systemPropertyVariables>
         </configuration>
       </plugin>
@@ -371,6 +460,30 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
       <version>1.21.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mysql</artifactId>
+      <version>1.21.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>8.4.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mariadb</artifactId>
+      <version>1.21.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
+      <version>3.5.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/resources/META-INF/jpa-changelog-phasetwo-20260421.xml
+++ b/src/main/resources/META-INF/jpa-changelog-phasetwo-20260421.xml
@@ -13,6 +13,18 @@
         </sql>
     </changeSet>
 
+    <changeSet author="vilmos.nagy" id="add-organization-attribute-name-value-index-mysql" dbms="mysql">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="IDX_ORG_ATTR_NAME_VALUE"/>
+            </not>
+        </preConditions>
+        <sql>
+            CREATE INDEX IDX_ORG_ATTR_NAME_VALUE
+                ON ORGANIZATION_ATTRIBUTE (NAME, VALUE(100))
+        </sql>
+    </changeSet>
+
     <changeSet author="phasetwo" id="add-organization-attribute-name-value-index">
         <preConditions onFail="MARK_RAN">
             <not>

--- a/src/test/java/io/phasetwo/service/resource/AbstractDbCompatibilityTest.java
+++ b/src/test/java/io/phasetwo/service/resource/AbstractDbCompatibilityTest.java
@@ -1,0 +1,191 @@
+package io.phasetwo.service.resource;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.phasetwo.client.openapi.model.OrganizationRepresentation;
+import io.phasetwo.service.KeycloakOrgsAdminAPI;
+import jakarta.ws.rs.core.Response.Status;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.jbosslog.JBossLog;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.keycloak.admin.client.Keycloak;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.utility.MountableFile;
+
+/**
+ * Base class for database-compatibility smoke tests. To add support for a new database, extend
+ * this class, annotate it with {@code @TestInstance(Lifecycle.PER_CLASS)}, and implement the three
+ * abstract methods. The inherited {@code @Test} will run automatically.
+ *
+ * <p>Tests only execute when {@code -Dinclude.integration=true} is set (activated by the
+ * {@code integration-tests} Maven profile).
+ */
+@JBossLog
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfSystemProperty(named = "include.integration", matches = "true")
+abstract class AbstractDbCompatibilityTest {
+
+  static final String KEYCLOAK_IMAGE =
+      String.format(
+          "quay.io/phasetwo/keycloak-crdb:%s", System.getProperty("keycloak-version", "26.5.7"));
+  static final String REALM = "master";
+  static final String ADMIN_CLI = "admin-cli";
+
+  static final String[] DEPS = {
+    "dnsjava:dnsjava",
+    "org.wildfly.client:wildfly-client-config",
+    "org.jboss.resteasy:resteasy-client",
+    "org.jboss.resteasy:resteasy-client-api",
+    "org.keycloak:keycloak-admin-client",
+    "io.phasetwo.keycloak:keycloak-events"
+  };
+
+  static List<File> getDeps() {
+    List<File> deps = new ArrayList<>();
+    for (String dep : DEPS) {
+      deps.addAll(
+          Maven.resolver()
+              .loadPomFromFile("./pom.xml")
+              .resolve(dep)
+              .withoutTransitivity()
+              .asList(File.class));
+    }
+    return deps;
+  }
+
+  // Instance fields — non-static so each concrete subclass owns its own containers.
+  Network network;
+  JdbcDatabaseContainer<?> db;
+  KeycloakContainer keycloak;
+  Keycloak adminClient;
+
+  /**
+   * Return a fully configured database container attached to {@code network}. Set the network alias
+   * here; it must match what {@link #getDbInternalUrl()} uses.
+   */
+  protected abstract JdbcDatabaseContainer<?> createDbContainer(Network network);
+
+  /** Value passed to Keycloak as {@code KC_DB} (e.g. {@code "mysql"}, {@code "mariadb"}). */
+  protected abstract String getDbVendor();
+
+  /**
+   * JDBC URL that the Keycloak container will use to reach the database over the shared Docker
+   * network (e.g. {@code "jdbc:mysql://mysql-db:3306/keycloak"}).
+   */
+  protected abstract String getDbInternalUrl();
+
+  @BeforeAll
+  void setUp() {
+    network = Network.newNetwork();
+    db = createDbContainer(network);
+    db.start();
+    keycloak = buildKeycloakContainer();
+    keycloak.start();
+    adminClient =
+        Keycloak.getInstance(
+            keycloak.getAuthServerUrl(),
+            REALM,
+            keycloak.getAdminUsername(),
+            keycloak.getAdminPassword(),
+            ADMIN_CLI);
+  }
+
+  @AfterAll
+  void tearDown() throws IOException {
+    if (keycloak != null) stopKeycloak(keycloak);
+    if (db != null) db.stop();
+    if (network != null) network.close();
+  }
+
+  @Test
+  void createSearchDeleteOrganization() throws Exception {
+    KeycloakOrgsAdminAPI orgsApi =
+        new KeycloakOrgsAdminAPI(keycloak.getAuthServerUrl(), REALM, adminClient);
+
+    OrganizationRepresentation created =
+        orgsApi.createOrganization(new OrganizationRepresentation().name("smoke-test-org"));
+    String orgId = created.getId();
+    assertNotNull(orgId);
+    assertThat(created.getName(), is("smoke-test-org"));
+
+    List<OrganizationRepresentation> orgs = orgsApi.listOrganizations();
+    assertThat(
+        "created org must appear in listing",
+        orgs.stream().anyMatch(o -> orgId.equals(o.getId())),
+        is(true));
+
+    given()
+        .baseUri(keycloak.getAuthServerUrl())
+        .basePath("realms/" + REALM + "/orgs")
+        .contentType("application/json")
+        .auth()
+        .oauth2(adminClient.tokenManager().getAccessTokenString())
+        .delete(orgId)
+        .then()
+        .statusCode(Status.NO_CONTENT.getStatusCode());
+
+    orgs = orgsApi.listOrganizations();
+    assertThat(
+        "deleted org must not appear in listing",
+        orgs.stream().noneMatch(o -> orgId.equals(o.getId())),
+        is(true));
+  }
+
+  private KeycloakContainer buildKeycloakContainer() {
+    KeycloakContainer kc =
+        new KeycloakContainer(KEYCLOAK_IMAGE)
+            .withNetwork(network)
+            .withContextPath("/auth")
+            .withImagePullPolicy(PullPolicy.alwaysPull())
+            .withProviderClassesFrom("target/classes")
+            .withProviderLibsFrom(getDeps())
+            .withEnv("KC_DB", getDbVendor())
+            .withEnv("KC_DB_URL", getDbInternalUrl())
+            .withEnv("KC_DB_USERNAME", db.getUsername())
+            .withEnv("KC_DB_PASSWORD", db.getPassword());
+    if (isJacocoPresent()) {
+      kc =
+          kc.withCopyFileToContainer(
+                  MountableFile.forHostPath("target/jacoco-agent/"), "/jacoco-agent")
+              .withEnv(
+                  "JAVA_OPTS",
+                  "-XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m"
+                      + " -javaagent:/jacoco-agent/org.jacoco.agent-runtime.jar=destfile=/tmp/jacoco.exec");
+    } else {
+      kc = kc.withEnv("JAVA_OPTS", "-XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m");
+    }
+    return kc;
+  }
+
+  static boolean isJacocoPresent() {
+    return Files.exists(Path.of("target/jacoco-agent/org.jacoco.agent-runtime.jar"));
+  }
+
+  static void stopKeycloak(KeycloakContainer kc) throws IOException {
+    if (isJacocoPresent()) {
+      String containerId = kc.getContainerId();
+      String shortId = containerId.length() > 12 ? containerId.substring(0, 12) : containerId;
+      kc.getDockerClient().stopContainerCmd(containerId).exec();
+      Files.createDirectories(Path.of("target", "jacoco-report"));
+      kc.copyFileFromContainer(
+          "/tmp/jacoco.exec", "./target/jacoco-report/jacoco-%s.exec".formatted(shortId));
+    }
+    kc.stop();
+  }
+}

--- a/src/test/java/io/phasetwo/service/resource/InitRolesPostMigrationTest.java
+++ b/src/test/java/io/phasetwo/service/resource/InitRolesPostMigrationTest.java
@@ -12,8 +12,6 @@ import io.phasetwo.client.openapi.model.OrganizationRepresentation;
 import io.phasetwo.service.KeycloakOrgsAdminAPI;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -128,10 +126,6 @@ public class InitRolesPostMigrationTest {
     if (toxiproxy != null) toxiproxy.stop();
   }
 
-  private static boolean isJacocoPresent() {
-    return Files.exists(Path.of("target/jacoco-agent/org.jacoco.agent-runtime.jar"));
-  }
-
   private static KeycloakContainer buildKeycloakContainer() {
     return buildKeycloakContainer(Map.of());
   }
@@ -149,7 +143,7 @@ public class InitRolesPostMigrationTest {
             .withEnv("KC_DB_USERNAME", "keycloak")
             .withEnv("KC_DB_PASSWORD", "keycloak");
     additionalEnvvars.forEach(kc::withEnv);
-    if (isJacocoPresent()) {
+    if (AbstractDbCompatibilityTest.isJacocoPresent()) {
       kc =
           kc.withCopyFileToContainer(
                   MountableFile.forHostPath("target/jacoco-agent/"), "/jacoco-agent")
@@ -176,15 +170,7 @@ public class InitRolesPostMigrationTest {
   // Each container gets its own .exec file (keyed by short container ID); the maven jacoco:merge
   // goal combines all .exec files in target/jacoco-report/ into a single report.
   private static void stopKeycloak(KeycloakContainer kc) throws IOException {
-    if (isJacocoPresent()) {
-      String containerId = kc.getContainerId();
-      String shortId = containerId.length() > 12 ? containerId.substring(0, 12) : containerId;
-      kc.getDockerClient().stopContainerCmd(containerId).exec();
-      Files.createDirectories(Path.of("target", "jacoco-report"));
-      kc.copyFileFromContainer(
-          "/tmp/jacoco.exec", "./target/jacoco-report/jacoco-%s.exec".formatted(shortId));
-    }
-    kc.stop();
+    AbstractDbCompatibilityTest.stopKeycloak(kc);
   }
 
   private static void restartKeycloak() throws IOException {

--- a/src/test/java/io/phasetwo/service/resource/MariaDBCompatibilityTest.java
+++ b/src/test/java/io/phasetwo/service/resource/MariaDBCompatibilityTest.java
@@ -1,0 +1,30 @@
+package io.phasetwo.service.resource;
+
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.Network;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MariaDBCompatibilityTest extends AbstractDbCompatibilityTest {
+
+  @Override
+  protected JdbcDatabaseContainer<?> createDbContainer(Network network) {
+    return new MariaDBContainer<>("mariadb:11.8")
+        .withNetwork(network)
+        .withNetworkAliases("mariadb-db")
+        .withDatabaseName("keycloak")
+        .withUsername("keycloak")
+        .withPassword("keycloak");
+  }
+
+  @Override
+  protected String getDbVendor() {
+    return "mariadb";
+  }
+
+  @Override
+  protected String getDbInternalUrl() {
+    return "jdbc:mariadb://mariadb-db:3306/keycloak";
+  }
+}

--- a/src/test/java/io/phasetwo/service/resource/MySQLCompatibilityTest.java
+++ b/src/test/java/io/phasetwo/service/resource/MySQLCompatibilityTest.java
@@ -1,0 +1,30 @@
+package io.phasetwo.service.resource;
+
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.Network;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MySQLCompatibilityTest extends AbstractDbCompatibilityTest {
+
+  @Override
+  protected JdbcDatabaseContainer<?> createDbContainer(Network network) {
+    return new MySQLContainer<>("mysql:8.4")
+        .withNetwork(network)
+        .withNetworkAliases("mysql-db")
+        .withDatabaseName("keycloak")
+        .withUsername("keycloak")
+        .withPassword("keycloak");
+  }
+
+  @Override
+  protected String getDbVendor() {
+    return "mysql";
+  }
+
+  @Override
+  protected String getDbInternalUrl() {
+    return "jdbc:mysql://mysql-db:3306/keycloak";
+  }
+}

--- a/src/test/java/io/phasetwo/service/resource/PostgreSQLCompatibilityTest.java
+++ b/src/test/java/io/phasetwo/service/resource/PostgreSQLCompatibilityTest.java
@@ -1,0 +1,30 @@
+package io.phasetwo.service.resource;
+
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class PostgreSQLCompatibilityTest extends AbstractDbCompatibilityTest {
+
+  @Override
+  protected JdbcDatabaseContainer<?> createDbContainer(Network network) {
+    return new PostgreSQLContainer<>("postgres:18")
+        .withNetwork(network)
+        .withNetworkAliases("postgres-db")
+        .withDatabaseName("keycloak")
+        .withUsername("keycloak")
+        .withPassword("keycloak");
+  }
+
+  @Override
+  protected String getDbVendor() {
+    return "postgres";
+  }
+
+  @Override
+  protected String getDbInternalUrl() {
+    return "jdbc:postgresql://postgres-db:5432/keycloak";
+  }
+}


### PR DESCRIPTION
Following https://github.com/p2-inc/keycloak-orgs/pull/450, this PR expands the README with details on supported databases and introduces a smoke test to verify that the plugin starts successfully with each target database.