### PR TITLE
Add surefire.rerunFailingTestsCount=2 for flaky test detection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,7 @@
           <classpathDependencyExcludes>
             <classpathDependencyExclude>org.jboss.slf4j:slf4j-jboss-logmanager</classpathDependencyExclude>
           </classpathDependencyExcludes>
+          <rerunFailingTestsCount>2</rerunFailingTestsCount>
           <systemPropertyVariables>
             <keycloak-version>${keycloak.version}</keycloak-version>
             <include.cypress>${include.cypress}</include.cypress>


### PR DESCRIPTION
Maven Surefire will retry each failing test up to 2 additional times. If a test fails on the first attempt but passes on a retry it is recorded as <flakyFailure> in the surefire XML report rather than a hard failure, making flaky tests visible without breaking the build.