### PR TITLE
Add .editorconfig with Google Java Style and IntelliJ ij_ settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,106 @@
+# EditorConfig — Google Java Style Guide
+# Enforced at build time by fmt-maven-plugin (google-java-format).
+#
+# google-java-format is intentionally non-configurable; this file makes your
+# editor match what the formatter will produce so you see no diffs on save.
+#
+# References:
+#   https://google.github.io/styleguide/javaguide.html
+#   https://github.com/spotify/fmt-maven-plugin
+#   https://github.com/google/google-java-format
+
+root = true
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Defaults for every file in the project
+# ──────────────────────────────────────────────────────────────────────────────
+[*]
+charset                  = utf-8
+end_of_line              = lf
+insert_final_newline     = true
+trim_trailing_whitespace = true
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Java  — mirrors google-java-format output exactly
+#
+# Key rules from the Google Java Style Guide:
+#   § 2.3.1  UTF-8 source files
+#   § 3.1    One statement per line (handled by formatter)
+#   § 4.1    Braces: K&R style, always used (handled by formatter)
+#   § 4.2    Block indentation: +2 spaces (NOT tabs)
+#   § 4.3    One statement per line
+#   § 4.4    Column limit: 100 characters
+#   § 4.5.2  Continuation lines: +4 spaces (handled by formatter)
+#   § 4.6.1  Vertical whitespace (handled by formatter)
+#
+# Note: google-java-format hard-wraps at 100 columns and uses 2-space indent.
+#       There is no option to change either value — do not override them here.
+# ──────────────────────────────────────────────────────────────────────────────
+[*.java]
+indent_style             = space
+indent_size              = 2
+tab_width                = 2
+max_line_length          = 100
+insert_final_newline     = true
+trim_trailing_whitespace = true
+
+# IntelliJ IDEA — align with google-java-format output so saves don't produce diffs
+
+# Imports: prevent wildcard collapse (fmt always expands wildcards); static-first ordering
+ij_java_use_single_class_imports            = true
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_names_count_to_use_import_on_demand = 999
+ij_java_imports_layout                      = $*,|,*
+
+# Continuation indent: Google §4.5.2 specifies +4; IntelliJ defaults to 8
+ij_java_continuation_indent_size            = 4
+
+# Alignment: google-java-format never aligns params or chained calls; IntelliJ does by default
+ij_java_align_multiline_parameters          = false
+ij_java_align_multiline_chained_methods     = false
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Maven build files
+# ──────────────────────────────────────────────────────────────────────────────
+[*.xml]
+indent_style             = space
+indent_size              = 2
+max_line_length          = 120
+
+# ──────────────────────────────────────────────────────────────────────────────
+# IntelliJ IDEA project files
+# (keep consistent so VCS diffs stay clean)
+# ──────────────────────────────────────────────────────────────────────────────
+[*.iml]
+indent_style             = space
+indent_size              = 2
+
+[{.idea/**,*.ipr,*.iws}]
+indent_style             = space
+indent_size              = 2
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Properties & config files
+# ──────────────────────────────────────────────────────────────────────────────
+[*.properties]
+indent_style             = space
+indent_size              = 2
+
+[*.{yml,yaml}]
+indent_style             = space
+indent_size              = 2
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Shell scripts — keep LF even on Windows checkouts
+# ──────────────────────────────────────────────────────────────────────────────
+[*.sh]
+end_of_line              = lf
+indent_style             = space
+indent_size              = 2
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Markdown — trailing spaces are intentional line-breaks; don't trim them
+# ──────────────────────────────────────────────────────────────────────────────
+[*.md]
+trim_trailing_whitespace = false
+max_line_length          = off

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The easiest way to get started is our [Docker image](https://quay.io/repository/
 
 ## Building and testing
 
-Checkout this project and run `mvn clean install`, which will build the source, run all unit/integration tests, and produce a jar in the `target/` directory.
+Checkout this project and run `mvn clean install`, which will build the source, run all unit/integration tests, and produce a jar in the `target/` directory. The build enforces Google Java formatting standards via the Spotify `fmt-maven-plugin`; run `mvn fmt:format` to auto-format your code before committing.
 
 ### Cypress tests
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.phasetwo.keycloak</groupId>
   <artifactId>keycloak-orgs</artifactId>
@@ -10,9 +11,9 @@
   <url>https://github.com/p2-inc/keycloak-orgs</url>
 
   <parent>
-    <groupId>com.github.xgp</groupId>
+    <groupId>io.phasetwo</groupId>
     <artifactId>oss-parent</artifactId>
-    <version>0.7</version>
+    <version>0.11</version>
   </parent>
 
   <developers>
@@ -71,7 +72,8 @@
                 </goals>
                 <configuration>
                   <target>
-                    <echo level="warn" message="[DEPRECATED] The cypress-tests profile is deprecated. Please use -Pintegration-tests instead, which runs Cypress and the database-compatibility smoke tests." />
+                    <echo level="warn"
+                          message="[DEPRECATED] The cypress-tests profile is deprecated. Please use -Pintegration-tests instead, which runs Cypress and the database-compatibility smoke tests."/>
                   </target>
                 </configuration>
               </execution>
@@ -215,20 +217,18 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.3.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.12.0</version>
         <configuration>
-            <source>${java.version}</source>
+          <source>${java.version}</source>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
         <configuration>
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
           <source>${java.version}</source>
@@ -253,7 +253,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>1.4</version>
         <executions>
           <execution>
             <id>detect-scm-revision</id>
@@ -291,7 +290,6 @@
       <plugin> <!-- pretty up the code using google java standards `mvn fmt:format` -->
         <groupId>com.spotify.fmt</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.29</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Enforces google-java-format conventions in editors (indent, imports, continuation indent, alignment) to prevent diffs between IDE and build formatter. Also notes fmt-maven-plugin enforcement in README.