### PR TITLE
Apply google-java-format across all source files

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/ConditionalOrgAttributeMatchesClientAttribute.java
+++ b/src/main/java/io/phasetwo/service/auth/ConditionalOrgAttributeMatchesClientAttribute.java
@@ -1,6 +1,5 @@
 package io.phasetwo.service.auth;
 
-
 import io.phasetwo.service.model.OrganizationProvider;
 import java.util.Map;
 import lombok.extern.jbosslog.JBossLog;

--- a/src/main/java/io/phasetwo/service/auth/idp/AbstractHomeIdpDiscoveryAuthenticatorFactory.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/AbstractHomeIdpDiscoveryAuthenticatorFactory.java
@@ -1,7 +1,13 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
+import static org.keycloak.models.AuthenticationExecutionModel.Requirement.*;
+
 import io.phasetwo.service.auth.idp.discovery.spi.HomeIdpDiscoverer;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.keycloak.Config;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.AuthenticatorFactory;
@@ -11,117 +17,109 @@ import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ServerInfoAwareProviderFactory;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.keycloak.models.AuthenticationExecutionModel.Requirement.*;
-
 /**
- * Provides a base implementation for authenticator factories that integrate custom identity provider
- * discovery mechanisms within authentication flow of this extension. This abstract class simplifies
- * the creation of authenticator instances by encapsulating common logic and providing a framework
- * for extending the discovery functionality through custom {@link HomeIdpDiscoverer} implementations.
- * <p>
- * Implementors of this class need to provide their own {@link DiscovererConfig}, which includes
+ * Provides a base implementation for authenticator factories that integrate custom identity
+ * provider discovery mechanisms within authentication flow of this extension. This abstract class
+ * simplifies the creation of authenticator instances by encapsulating common logic and providing a
+ * framework for extending the discovery functionality through custom {@link HomeIdpDiscoverer}
+ * implementations.
+ *
+ * <p>Implementors of this class need to provide their own {@link DiscovererConfig}, which includes
  * the discovery logic specifics and configuration properties. This approach ensures flexibility and
- * customizability, enabling developers to tailor the identity provider discovery process to specific
- * organizational needs or authentication scenarios.
- * </p>
- * <p>
- * By inheriting from this class, developers can focus on the specifics of their discovery logic
+ * customizability, enabling developers to tailor the identity provider discovery process to
+ * specific organizational needs or authentication scenarios.
+ *
+ * <p>By inheriting from this class, developers can focus on the specifics of their discovery logic
  * without worrying about the boilerplate associated with UI integration and redirection logic.
- * </p>
  *
  * @see DiscovererConfig
  */
 @PublicAPI(unstable = true)
-public abstract class AbstractHomeIdpDiscoveryAuthenticatorFactory implements AuthenticatorFactory, ServerInfoAwareProviderFactory {
-    private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = new AuthenticationExecutionModel.Requirement[]{REQUIRED, ALTERNATIVE, DISABLED};
+public abstract class AbstractHomeIdpDiscoveryAuthenticatorFactory
+    implements AuthenticatorFactory, ServerInfoAwareProviderFactory {
+  private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES =
+      new AuthenticationExecutionModel.Requirement[] {REQUIRED, ALTERNATIVE, DISABLED};
 
-    private final DiscovererConfig discovererConfig;
+  private final DiscovererConfig discovererConfig;
 
-    protected AbstractHomeIdpDiscoveryAuthenticatorFactory(DiscovererConfig discovererConfig) {
-        this.discovererConfig = discovererConfig;
-    }
+  protected AbstractHomeIdpDiscoveryAuthenticatorFactory(DiscovererConfig discovererConfig) {
+    this.discovererConfig = discovererConfig;
+  }
 
-    @Override
-    public final boolean isConfigurable() {
-        return true;
-    }
+  @Override
+  public final boolean isConfigurable() {
+    return true;
+  }
 
-    @Override
-    public final AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
-        return REQUIREMENT_CHOICES;
-    }
+  @Override
+  public final AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+    return REQUIREMENT_CHOICES;
+  }
 
-    @Override
-    public final boolean isUserSetupAllowed() {
-        return false;
-    }
+  @Override
+  public final boolean isUserSetupAllowed() {
+    return false;
+  }
 
-    @Override
-    public final List<ProviderConfigProperty> getConfigProperties() {
-        return Stream.concat(
-                HomeIdpForwarderConfigProperties.CONFIG_PROPERTIES.stream(),
-                discovererConfig.getProperties().stream())
-            .collect(Collectors.toList());
-    }
+  @Override
+  public final List<ProviderConfigProperty> getConfigProperties() {
+    return Stream.concat(
+            HomeIdpForwarderConfigProperties.CONFIG_PROPERTIES.stream(),
+            discovererConfig.getProperties().stream())
+        .collect(Collectors.toList());
+  }
 
-    @Override
-    public final Authenticator create(KeycloakSession session) {
-        return new HomeIdpDiscoveryAuthenticator(discovererConfig);
-    }
+  @Override
+  public final Authenticator create(KeycloakSession session) {
+    return new HomeIdpDiscoveryAuthenticator(discovererConfig);
+  }
 
-    @Override
-    public final void init(Config.Scope config) {
-    }
+  @Override
+  public final void init(Config.Scope config) {}
 
-    @Override
-    public final void postInit(KeycloakSessionFactory factory) {
-    }
+  @Override
+  public final void postInit(KeycloakSessionFactory factory) {}
 
-    @Override
-    public final void close() {
-    }
+  @Override
+  public final void close() {}
 
-    @Override
-    public final Map<String, String> getOperationalInfo() {
-        return OperationalInfo.get();
-    }
+  @Override
+  public final Map<String, String> getOperationalInfo() {
+    return OperationalInfo.get();
+  }
+
+  /**
+   * Represents the configuration settings for a {@link HomeIdpDiscoverer} implementation. This
+   * interface is designed to allow for dynamic specification of configuration properties necessary
+   * for the discovery of home Identity Providers (IdPs). The configurations defined by an
+   * implementation of this interface provide the parameters and metadata required by a discoverer
+   * to properly integrate with {@link HomeIdpDiscoveryAuthenticator}.
+   *
+   * @see HomeIdpDiscoverer
+   */
+  @PublicAPI(unstable = true)
+  public interface DiscovererConfig {
+    /**
+     * Retrieves a list of {@link ProviderConfigProperty} objects that define the configuration
+     * properties available for the discoverer. Each {@code ProviderConfigProperty} includes
+     * metadata such as the property name, type, label, default value, and other attributes
+     * necessary for configuring the discoverer identified by {@link #getProviderId()} dynamically
+     * at runtime.
+     *
+     * @return a list of {@link ProviderConfigProperty} that describes each configuration property
+     *     required by the discoverer. If no home properties are need for configuration, this method
+     *     must return an empty list.
+     */
+    List<ProviderConfigProperty> getProperties();
 
     /**
-     * Represents the configuration settings for a {@link HomeIdpDiscoverer} implementation. This interface
-     * is designed to allow for dynamic specification of configuration properties necessary for the
-     * discovery of home Identity Providers (IdPs). The configurations defined by an implementation of
-     * this interface provide the parameters and metadata required by a discoverer to properly integrate
-     * with {@link HomeIdpDiscoveryAuthenticator}.
+     * Returns the unique provider ID associated with the discoverer. This ID is used to uniquely
+     * identify and reference the specific discoverer implementation within the Keycloak system. The
+     * provider ID should be unique across all discoverer configurations to prevent conflicts and
+     * ensure correct operation.
      *
-     * @see HomeIdpDiscoverer
+     * @return the unique string identifier for the discoverer provider.
      */
-    @PublicAPI(unstable = true)
-    public interface DiscovererConfig {
-        /**
-         * Retrieves a list of {@link ProviderConfigProperty} objects that define the configuration
-         * properties available for the discoverer. Each {@code ProviderConfigProperty} includes metadata
-         * such as the property name, type, label, default value, and other attributes necessary for
-         * configuring the discoverer identified by {@link #getProviderId()} dynamically at runtime.
-         *
-         * @return a list of {@link ProviderConfigProperty} that describes each configuration property
-         *         required by the discoverer. If no home properties are need for configuration, this method must
-         *         return an empty list.
-         */
-        List<ProviderConfigProperty> getProperties();
-
-        /**
-         * Returns the unique provider ID associated with the discoverer. This ID is used to uniquely
-         * identify and reference the specific discoverer implementation within the Keycloak system.
-         * The provider ID should be unique across all discoverer configurations to prevent conflicts
-         * and ensure correct operation.
-         *
-         * @return the unique string identifier for the discoverer provider.
-         */
-        String getProviderId();
-    }
+    String getProviderId();
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/AlwaysSelectableIdentityProviderModel.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/AlwaysSelectableIdentityProviderModel.java
@@ -1,27 +1,25 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
-
-import org.keycloak.models.IdentityProviderModel;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.keycloak.models.IdentityProviderModel;
 
 final class AlwaysSelectableIdentityProviderModel extends IdentityProviderModel {
 
-    AlwaysSelectableIdentityProviderModel(IdentityProviderModel delegate) {
-        super(delegate);
-    }
+  AlwaysSelectableIdentityProviderModel(IdentityProviderModel delegate) {
+    super(delegate);
+  }
 
-    @Override
-    public Boolean isHideOnLogin() {
-        return false;
-    }
+  @Override
+  public Boolean isHideOnLogin() {
+    return false;
+  }
 
-    @Override
-    public Map<String, String> getConfig() {
-        Map<String, String> superConfig = new HashMap<>(super.getConfig());
-        superConfig.put("hideOnLoginPage", Boolean.FALSE.toString());
-        return superConfig;
-    }
-
+  @Override
+  public Map<String, String> getConfig() {
+    Map<String, String> superConfig = new HashMap<>(super.getConfig());
+    superConfig.put("hideOnLoginPage", Boolean.FALSE.toString());
+    return superConfig;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/AuthenticationChallenge.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/AuthenticationChallenge.java
@@ -1,62 +1,67 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Optional;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.services.managers.AuthenticationManager;
 
-import java.util.List;
-import java.util.Optional;
-
 final class AuthenticationChallenge {
 
-    private final AuthenticationFlowContext context;
-    private final RememberMe rememberMe;
-    private final LoginHint loginHint;
-    private final LoginForm loginForm;
-    private final Reauthentication reauthentication;
+  private final AuthenticationFlowContext context;
+  private final RememberMe rememberMe;
+  private final LoginHint loginHint;
+  private final LoginForm loginForm;
+  private final Reauthentication reauthentication;
 
-    AuthenticationChallenge(AuthenticationFlowContext context, RememberMe rememberMe, LoginHint loginHint, LoginForm loginForm, Reauthentication reauthentication) {
-        this.context = context;
-        this.rememberMe = rememberMe;
-        this.loginHint = loginHint;
-        this.loginForm = loginForm;
-        this.reauthentication = reauthentication;
-    }
+  AuthenticationChallenge(
+      AuthenticationFlowContext context,
+      RememberMe rememberMe,
+      LoginHint loginHint,
+      LoginForm loginForm,
+      Reauthentication reauthentication) {
+    this.context = context;
+    this.rememberMe = rememberMe;
+    this.loginHint = loginHint;
+    this.loginForm = loginForm;
+    this.reauthentication = reauthentication;
+  }
 
-    void forceChallenge() {
-        MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
-        String loginHintUsername = loginHint.getFromSession();
+  void forceChallenge() {
+    MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
+    String loginHintUsername = loginHint.getFromSession();
 
-        String rememberMeUsername = rememberMe.getUserName();
+    String rememberMeUsername = rememberMe.getUserName();
 
-        Response challengeResponse;
-        if (reauthentication.required() && context.getUser() != null) {
-            String attribute = Optional.ofNullable(context.getAuthenticatorConfig())
-                .map(it -> it.getConfig().getOrDefault("userAttribute", "email").trim())
-                .orElse("email");
-            formData.add(AuthenticationManager.FORM_USERNAME, context.getUser().getFirstAttribute(attribute));
-            challengeResponse = loginForm.createWithSignInButtonOnly(formData);
+    Response challengeResponse;
+    if (reauthentication.required() && context.getUser() != null) {
+      String attribute =
+          Optional.ofNullable(context.getAuthenticatorConfig())
+              .map(it -> it.getConfig().getOrDefault("userAttribute", "email").trim())
+              .orElse("email");
+      formData.add(
+          AuthenticationManager.FORM_USERNAME, context.getUser().getFirstAttribute(attribute));
+      challengeResponse = loginForm.createWithSignInButtonOnly(formData);
+    } else {
+      if (loginHintUsername != null || rememberMeUsername != null) {
+        if (loginHintUsername != null) {
+          formData.add(AuthenticationManager.FORM_USERNAME, loginHintUsername);
         } else {
-            if (loginHintUsername != null || rememberMeUsername != null) {
-                if (loginHintUsername != null) {
-                    formData.add(AuthenticationManager.FORM_USERNAME, loginHintUsername);
-                } else {
-                    formData.add(AuthenticationManager.FORM_USERNAME, rememberMeUsername);
-                    formData.add("rememberMe", "on");
-                }
-            }
-            challengeResponse = loginForm.create(formData);
+          formData.add(AuthenticationManager.FORM_USERNAME, rememberMeUsername);
+          formData.add("rememberMe", "on");
         }
-
-        context.challenge(challengeResponse);
+      }
+      challengeResponse = loginForm.create(formData);
     }
 
-    void forceChallenge(List<IdentityProviderModel> homeIdps) {
-        context.forceChallenge(loginForm.create(homeIdps));
-    }
+    context.challenge(challengeResponse);
+  }
 
+  void forceChallenge(List<IdentityProviderModel> homeIdps) {
+    context.forceChallenge(loginForm.create(homeIdps));
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/BaseUriLoginFormsProvider.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/BaseUriLoginFormsProvider.java
@@ -1,29 +1,29 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
 import jakarta.ws.rs.core.UriBuilder;
+import java.net.URI;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProvider;
 import org.keycloak.services.resources.LoginActionsService;
 
-import java.net.URI;
-
 /**
- * Workaround to reuse the logic in FreeMarkerLoginFormsProvider.prepareBaseUriBuilder, so no need to reimplement it.
+ * Workaround to reuse the logic in FreeMarkerLoginFormsProvider.prepareBaseUriBuilder, so no need
+ * to reimplement it.
  */
 final class BaseUriLoginFormsProvider extends FreeMarkerLoginFormsProvider {
 
-    public BaseUriLoginFormsProvider(AuthenticationFlowContext context) {
-        super(context.getSession());
-        super.setAuthenticationSession(context.getAuthenticationSession());
-        super.setClientSessionCode(context.generateAccessCode());
-    }
+  public BaseUriLoginFormsProvider(AuthenticationFlowContext context) {
+    super(context.getSession());
+    super.setAuthenticationSession(context.getAuthenticationSession());
+    super.setClientSessionCode(context.generateAccessCode());
+  }
 
-    public URI  getBaseUriWithCodeAndClientId() {
-        UriBuilder baseUriBuilder = super.prepareBaseUriBuilder(false);
-        if (accessCode != null) {
-            baseUriBuilder.queryParam(LoginActionsService.SESSION_CODE, accessCode);
-        }
-        return baseUriBuilder.build();
+  public URI getBaseUriWithCodeAndClientId() {
+    UriBuilder baseUriBuilder = super.prepareBaseUriBuilder(false);
+    if (accessCode != null) {
+      baseUriBuilder.queryParam(LoginActionsService.SESSION_CODE, accessCode);
     }
+    return baseUriBuilder.build();
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpAuthenticationFlowContext.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpAuthenticationFlowContext.java
@@ -1,4 +1,4 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
 import io.phasetwo.service.auth.idp.discovery.spi.HomeIdpDiscoverer;
@@ -6,89 +6,95 @@ import org.keycloak.authentication.AuthenticationFlowContext;
 
 final class HomeIdpAuthenticationFlowContext {
 
-    private final AuthenticationFlowContext context;
-    private HomeIdpForwarderConfig config;
-    private LoginPage loginPage;
-    private LoginHint loginHint;
-    private HomeIdpDiscoverer discoverer;
-    private RememberMe rememberMe;
-    private AuthenticationChallenge authenticationChallenge;
-    private Redirector redirector;
-    private BaseUriLoginFormsProvider loginFormsProvider;
-    private LoginForm loginForm;
-    private Reauthentication reauthentication;
+  private final AuthenticationFlowContext context;
+  private HomeIdpForwarderConfig config;
+  private LoginPage loginPage;
+  private LoginHint loginHint;
+  private HomeIdpDiscoverer discoverer;
+  private RememberMe rememberMe;
+  private AuthenticationChallenge authenticationChallenge;
+  private Redirector redirector;
+  private BaseUriLoginFormsProvider loginFormsProvider;
+  private LoginForm loginForm;
+  private Reauthentication reauthentication;
 
-    HomeIdpAuthenticationFlowContext(AuthenticationFlowContext context) {
-        this.context = context;
-    }
+  HomeIdpAuthenticationFlowContext(AuthenticationFlowContext context) {
+    this.context = context;
+  }
 
-    HomeIdpForwarderConfig config() {
-        if (config == null) {
-            config = new HomeIdpForwarderConfig(context.getAuthenticatorConfig());
-        }
-        return config;
+  HomeIdpForwarderConfig config() {
+    if (config == null) {
+      config = new HomeIdpForwarderConfig(context.getAuthenticatorConfig());
     }
+    return config;
+  }
 
-    LoginPage loginPage() {
-        if (loginPage == null) {
-            loginPage = new LoginPage(context, config(), reauthentication());
-        }
-        return  loginPage;
+  LoginPage loginPage() {
+    if (loginPage == null) {
+      loginPage = new LoginPage(context, config(), reauthentication());
     }
+    return loginPage;
+  }
 
-    LoginHint loginHint() {
-        if (loginHint == null) {
-            loginHint = new LoginHint(context, new Users(context.getSession()));
-        }
-        return loginHint;
+  LoginHint loginHint() {
+    if (loginHint == null) {
+      loginHint = new LoginHint(context, new Users(context.getSession()));
     }
+    return loginHint;
+  }
 
-    HomeIdpDiscoverer discoverer(AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig discovererConfig) {
-        if (discoverer == null) {
-            discoverer = context.getSession().getProvider(HomeIdpDiscoverer.class, discovererConfig.getProviderId());
-        }
-        return  discoverer;
+  HomeIdpDiscoverer discoverer(
+      AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig discovererConfig) {
+    if (discoverer == null) {
+      discoverer =
+          context
+              .getSession()
+              .getProvider(HomeIdpDiscoverer.class, discovererConfig.getProviderId());
     }
+    return discoverer;
+  }
 
-    RememberMe rememberMe() {
-        if (rememberMe == null) {
-            rememberMe = new RememberMe(context);
-        }
-        return rememberMe;
+  RememberMe rememberMe() {
+    if (rememberMe == null) {
+      rememberMe = new RememberMe(context);
     }
+    return rememberMe;
+  }
 
-    AuthenticationChallenge authenticationChallenge() {
-        if (authenticationChallenge == null) {
-            authenticationChallenge = new AuthenticationChallenge(context, rememberMe(), loginHint(), loginForm(), reauthentication());
-        }
-        return authenticationChallenge;
+  AuthenticationChallenge authenticationChallenge() {
+    if (authenticationChallenge == null) {
+      authenticationChallenge =
+          new AuthenticationChallenge(
+              context, rememberMe(), loginHint(), loginForm(), reauthentication());
     }
+    return authenticationChallenge;
+  }
 
-    Redirector redirector() {
-        if (redirector == null) {
-            redirector = new Redirector(context);
-        }
-        return redirector;
+  Redirector redirector() {
+    if (redirector == null) {
+      redirector = new Redirector(context);
     }
+    return redirector;
+  }
 
-    LoginForm loginForm() {
-        if (loginForm == null) {
-            loginForm = new LoginForm(context, loginFormsProvider());
-        }
-        return loginForm;
+  LoginForm loginForm() {
+    if (loginForm == null) {
+      loginForm = new LoginForm(context, loginFormsProvider());
     }
+    return loginForm;
+  }
 
-    BaseUriLoginFormsProvider loginFormsProvider() {
-        if (loginFormsProvider == null) {
-            loginFormsProvider = new BaseUriLoginFormsProvider(context);
-        }
-        return loginFormsProvider;
+  BaseUriLoginFormsProvider loginFormsProvider() {
+    if (loginFormsProvider == null) {
+      loginFormsProvider = new BaseUriLoginFormsProvider(context);
     }
+    return loginFormsProvider;
+  }
 
-    Reauthentication reauthentication() {
-        if (reauthentication == null) {
-            reauthentication = new Reauthentication(context);
-        }
-        return reauthentication;
+  Reauthentication reauthentication() {
+    if (reauthentication == null) {
+      reauthentication = new Reauthentication(context);
     }
+    return reauthentication;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoveryAuthenticator.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoveryAuthenticator.java
@@ -1,8 +1,11 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
+
+import static org.keycloak.services.validation.Validation.FIELD_USERNAME;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
@@ -14,187 +17,204 @@ import org.keycloak.models.*;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.services.managers.AuthenticationManager;
 
-import java.util.List;
-
-import static org.keycloak.services.validation.Validation.FIELD_USERNAME;
-
 final class HomeIdpDiscoveryAuthenticator extends AbstractUsernameFormAuthenticator {
 
-    private static final Logger LOG = Logger.getLogger(HomeIdpDiscoveryAuthenticator.class);
+  private static final Logger LOG = Logger.getLogger(HomeIdpDiscoveryAuthenticator.class);
 
-    private final AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig discovererConfig;
+  private final AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig discovererConfig;
 
-    HomeIdpDiscoveryAuthenticator(AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig discovererConfig) {
-        this.discovererConfig = discovererConfig;
+  HomeIdpDiscoveryAuthenticator(
+      AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig discovererConfig) {
+    this.discovererConfig = discovererConfig;
+  }
+
+  @Override
+  public void authenticate(AuthenticationFlowContext authenticationFlowContext) {
+    HomeIdpAuthenticationFlowContext context =
+        new HomeIdpAuthenticationFlowContext(authenticationFlowContext);
+
+    // backwards compatibilty with original keycloak-orgs port
+    String attemptedUsername = getAttemptedUsername(authenticationFlowContext);
+    if (attemptedUsername != null) {
+      if (authenticationFlowContext.getExecution().getRequirement()
+          == AuthenticationExecutionModel.Requirement.REQUIRED) {
+        action(authenticationFlowContext);
+      } else {
+        authenticationFlowContext.attempted();
+      }
+      return;
     }
 
-    @Override
-    public void authenticate(AuthenticationFlowContext authenticationFlowContext) {
-        HomeIdpAuthenticationFlowContext context = new HomeIdpAuthenticationFlowContext(authenticationFlowContext);
-
-        //backwards compatibilty with original keycloak-orgs port
-        String attemptedUsername = getAttemptedUsername(authenticationFlowContext);
-        if (attemptedUsername != null) {
-            if (authenticationFlowContext.getExecution().getRequirement() == AuthenticationExecutionModel.Requirement.REQUIRED) {
-                action(authenticationFlowContext);
-            } else {
-                authenticationFlowContext.attempted();
-            }
-            return;
+    if (context.loginPage().shouldByPass()) {
+      String usernameHint = usernameHint(authenticationFlowContext, context);
+      if (usernameHint != null) {
+        String username = setUserInContext(authenticationFlowContext, usernameHint);
+        final List<IdentityProviderModel> homeIdps =
+            context
+                .discoverer(discovererConfig)
+                .discoverForUser(authenticationFlowContext, username);
+        if (!homeIdps.isEmpty()) {
+          context.rememberMe().remember(username);
+          redirectOrChallenge(context, username, homeIdps);
+          return;
         }
-
-        if (context.loginPage().shouldByPass()) {
-            String usernameHint = usernameHint(authenticationFlowContext, context);
-            if (usernameHint != null) {
-                String username = setUserInContext(authenticationFlowContext, usernameHint);
-                final List<IdentityProviderModel> homeIdps = context.discoverer(discovererConfig).discoverForUser(authenticationFlowContext, username);
-                if (!homeIdps.isEmpty()) {
-                    context.rememberMe().remember(username);
-                    redirectOrChallenge(context, username, homeIdps);
-                    return;
-                }
-                //set attempted in order to bypass the need to multi input username/email in case the identity doesn't exist
-                if (authenticationFlowContext.getExecution().getRequirement() == AuthenticationExecutionModel.Requirement.REQUIRED) {
-                    authenticationFlowContext.success();
-                } else {
-                    authenticationFlowContext.attempted();
-                }
-            } else {
-                //if no username hint force challenge
-                context.authenticationChallenge().forceChallenge();
-            }
+        // set attempted in order to bypass the need to multi input username/email in case the
+        // identity doesn't exist
+        if (authenticationFlowContext.getExecution().getRequirement()
+            == AuthenticationExecutionModel.Requirement.REQUIRED) {
+          authenticationFlowContext.success();
         } else {
-            //if no bypass login force challenge
-            context.authenticationChallenge().forceChallenge();
+          authenticationFlowContext.attempted();
         }
+      } else {
+        // if no username hint force challenge
+        context.authenticationChallenge().forceChallenge();
+      }
+    } else {
+      // if no bypass login force challenge
+      context.authenticationChallenge().forceChallenge();
+    }
+  }
+
+  private String getAttemptedUsername(AuthenticationFlowContext context) {
+    return trimToNull(context.getAuthenticationSession().getAuthNote(ATTEMPTED_USERNAME));
+  }
+
+  private String usernameHint(
+      AuthenticationFlowContext authenticationFlowContext,
+      HomeIdpAuthenticationFlowContext context) {
+    String usernameHint = trimToNull(context.loginHint().getFromSession());
+    if (usernameHint == null) {
+      usernameHint =
+          trimToNull(
+              authenticationFlowContext.getAuthenticationSession().getAuthNote(ATTEMPTED_USERNAME));
+    }
+    return usernameHint;
+  }
+
+  private void redirectOrChallenge(
+      HomeIdpAuthenticationFlowContext context,
+      String username,
+      List<IdentityProviderModel> homeIdps) {
+    if (homeIdps.size() == 1 || context.config().forwardToFirstMatch()) {
+      IdentityProviderModel homeIdp = homeIdps.get(0);
+      context.loginHint().setInAuthSession(homeIdp, username);
+      context.redirector().redirectTo(homeIdp);
+    } else {
+      context.authenticationChallenge().forceChallenge(homeIdps);
+    }
+  }
+
+  @Override
+  public void action(AuthenticationFlowContext authenticationFlowContext) {
+    MultivaluedMap<String, String> formData =
+        authenticationFlowContext.getHttpRequest().getDecodedFormParameters();
+    if (formData.containsKey("cancel")) {
+      LOG.debugf("Login canceled");
+      authenticationFlowContext.cancelLogin();
+      return;
     }
 
-    private String getAttemptedUsername(AuthenticationFlowContext context) {
-        return trimToNull(context.getAuthenticationSession().getAuthNote(ATTEMPTED_USERNAME));
+    HomeIdpAuthenticationFlowContext context =
+        new HomeIdpAuthenticationFlowContext(authenticationFlowContext);
+
+    String tryUsername;
+    if (context.reauthentication().required() && authenticationFlowContext.getUser() != null) {
+      tryUsername = authenticationFlowContext.getUser().getUsername();
+    } else {
+      tryUsername = formData.getFirst(AuthenticationManager.FORM_USERNAME);
     }
 
-    private String usernameHint(AuthenticationFlowContext authenticationFlowContext, HomeIdpAuthenticationFlowContext context) {
-        String usernameHint = trimToNull(context.loginHint().getFromSession());
-        if (usernameHint == null) {
-            usernameHint = trimToNull(authenticationFlowContext.getAuthenticationSession().getAuthNote(ATTEMPTED_USERNAME));
-        }
-        return usernameHint;
+    String username = setUserInContext(authenticationFlowContext, tryUsername);
+    if (username == null) {
+      LOG.debugf("No username in request");
+      return;
     }
 
-    private void redirectOrChallenge(HomeIdpAuthenticationFlowContext context, String username, List<IdentityProviderModel> homeIdps) {
-        if (homeIdps.size() == 1 || context.config().forwardToFirstMatch()) {
-            IdentityProviderModel homeIdp = homeIdps.get(0);
-            context.loginHint().setInAuthSession(homeIdp, username);
-            context.redirector().redirectTo(homeIdp);
-        } else {
-            context.authenticationChallenge().forceChallenge(homeIdps);
-        }
+    final List<IdentityProviderModel> homeIdps =
+        context.discoverer(discovererConfig).discoverForUser(authenticationFlowContext, username);
+    if (homeIdps.isEmpty()) {
+      if (authenticationFlowContext.getExecution().getRequirement()
+          == AuthenticationExecutionModel.Requirement.REQUIRED) {
+        authenticationFlowContext.success();
+      } else {
+        authenticationFlowContext.attempted();
+      }
+      context.loginHint().setInAuthSession(username);
+    } else {
+      RememberMe rememberMe = context.rememberMe();
+      rememberMe.handleAction(formData);
+      rememberMe.remember(username);
+      redirectOrChallenge(context, username, homeIdps);
+    }
+  }
+
+  private String setUserInContext(AuthenticationFlowContext context, String username) {
+    context.clearUser();
+
+    username = trimToNull(username);
+
+    if (username == null) {
+      LOG.warn("No or empty username found in request");
+      context.getEvent().error(Errors.USER_NOT_FOUND);
+      Response challengeResponse =
+          challenge(context, getDefaultChallengeMessage(context), FIELD_USERNAME);
+      context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);
+      return null;
     }
 
-    @Override
-    public void action(AuthenticationFlowContext authenticationFlowContext) {
-        MultivaluedMap<String, String> formData = authenticationFlowContext.getHttpRequest().getDecodedFormParameters();
-        if (formData.containsKey("cancel")) {
-            LOG.debugf("Login canceled");
-            authenticationFlowContext.cancelLogin();
-            return;
-        }
+    LOG.debugf("Found username '%s' in request", username);
+    context.getEvent().detail(Details.USERNAME, username);
+    context.getAuthenticationSession().setAuthNote(ATTEMPTED_USERNAME, username);
 
-        HomeIdpAuthenticationFlowContext context = new HomeIdpAuthenticationFlowContext(authenticationFlowContext);
-
-        String tryUsername;
-        if (context.reauthentication().required() && authenticationFlowContext.getUser() != null) {
-            tryUsername = authenticationFlowContext.getUser().getUsername();
-        } else {
-            tryUsername = formData.getFirst(AuthenticationManager.FORM_USERNAME);
-        }
-
-        String username = setUserInContext(authenticationFlowContext, tryUsername);
-        if (username == null) {
-            LOG.debugf("No username in request");
-            return;
-        }
-
-
-        final List<IdentityProviderModel> homeIdps = context.discoverer(discovererConfig).discoverForUser(authenticationFlowContext, username);
-        if (homeIdps.isEmpty()) {
-            if (authenticationFlowContext.getExecution().getRequirement() == AuthenticationExecutionModel.Requirement.REQUIRED) {
-                authenticationFlowContext.success();
-            } else {
-                authenticationFlowContext.attempted();
-            }
-            context.loginHint().setInAuthSession(username);
-        } else {
-            RememberMe rememberMe = context.rememberMe();
-            rememberMe.handleAction(formData);
-            rememberMe.remember(username);
-            redirectOrChallenge(context, username, homeIdps);
-        }
+    try {
+      UserModel user =
+          KeycloakModelUtils.findUserByNameOrEmail(
+              context.getSession(), context.getRealm(), username);
+      if (user != null) {
+        LOG.tracef("Setting user '%s' in context", user.getId());
+        context.setUser(user);
+      }
+    } catch (ModelDuplicateException ex) {
+      LOG.warnf(
+          ex,
+          "Could not uniquely identify the user. Multiple users with name or email '%s' found.",
+          username);
     }
 
-    private String setUserInContext(AuthenticationFlowContext context, String username) {
-        context.clearUser();
+    return username;
+  }
 
-        username = trimToNull(username);
-
-        if (username == null) {
-            LOG.warn("No or empty username found in request");
-            context.getEvent().error(Errors.USER_NOT_FOUND);
-            Response challengeResponse = challenge(context, getDefaultChallengeMessage(context), FIELD_USERNAME);
-            context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);
-            return null;
-        }
-
-        LOG.debugf("Found username '%s' in request", username);
-        context.getEvent().detail(Details.USERNAME, username);
-        context.getAuthenticationSession().setAuthNote(ATTEMPTED_USERNAME, username);
-
-        try {
-            UserModel user = KeycloakModelUtils.findUserByNameOrEmail(context.getSession(), context.getRealm(),
-                    username);
-            if (user != null) {
-                LOG.tracef("Setting user '%s' in context", user.getId());
-                context.setUser(user);
-            }
-        } catch (ModelDuplicateException ex) {
-            LOG.warnf(ex, "Could not uniquely identify the user. Multiple users with name or email '%s' found.",
-                    username);
-        }
-
-        return username;
+  private static String trimToNull(String username) {
+    if (username != null) {
+      username = username.trim();
+      if ("".equalsIgnoreCase(username)) username = null;
     }
+    return username;
+  }
 
-    private static String trimToNull(String username) {
-        if (username != null) {
-            username = username.trim();
-            if ("".equalsIgnoreCase(username))
-                username = null;
-        }
-        return username;
-    }
+  @Override
+  protected Response createLoginForm(LoginFormsProvider form) {
+    return form.createLoginUsername();
+  }
 
-    @Override
-    protected Response createLoginForm(LoginFormsProvider form) {
-        return form.createLoginUsername();
-    }
+  @Override
+  protected String getDefaultChallengeMessage(AuthenticationFlowContext context) {
+    return context.getRealm().isLoginWithEmailAllowed()
+        ? "invalidUsernameOrEmailMessage"
+        : "invalidUsernameMessage";
+  }
 
-    @Override
-    protected String getDefaultChallengeMessage(AuthenticationFlowContext context) {
-        return context.getRealm().isLoginWithEmailAllowed() ? "invalidUsernameOrEmailMessage" : "invalidUsernameMessage";
-    }
+  @Override
+  public boolean requiresUser() {
+    return false;
+  }
 
-    @Override
-    public boolean requiresUser() {
-        return false;
-    }
+  @Override
+  public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+    return true;
+  }
 
-    @Override
-    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
-        return true;
-    }
-
-    @Override
-    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
-    }
-
+  @Override
+  public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {}
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoveryAuthenticatorFactory.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoveryAuthenticatorFactory.java
@@ -1,4 +1,4 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
 import com.google.auto.service.AutoService;
@@ -6,31 +6,32 @@ import io.phasetwo.service.auth.idp.discovery.extemail.EmailHomeIdpDiscoveryAuth
 import org.keycloak.authentication.AuthenticatorFactory;
 
 @AutoService(AuthenticatorFactory.class)
-public final class HomeIdpDiscoveryAuthenticatorFactory extends AbstractHomeIdpDiscoveryAuthenticatorFactory implements  AuthenticatorFactory {
+public final class HomeIdpDiscoveryAuthenticatorFactory
+    extends AbstractHomeIdpDiscoveryAuthenticatorFactory implements AuthenticatorFactory {
 
-    private static final String PROVIDER_ID = "ext-auth-home-idp-discovery";
+  private static final String PROVIDER_ID = "ext-auth-home-idp-discovery";
 
-    public HomeIdpDiscoveryAuthenticatorFactory() {
-        super(new EmailHomeIdpDiscoveryAuthenticatorFactoryDiscovererConfig());
-    }
+  public HomeIdpDiscoveryAuthenticatorFactory() {
+    super(new EmailHomeIdpDiscoveryAuthenticatorFactoryDiscovererConfig());
+  }
 
-    @Override
-    public String getDisplayType() {
-        return "Home IdP Discovery";
-    }
+  @Override
+  public String getDisplayType() {
+    return "Home IdP Discovery";
+  }
 
-    @Override
-    public String getReferenceCategory() {
-        return "Authorization";
-    }
+  @Override
+  public String getReferenceCategory() {
+    return "Authorization";
+  }
 
-    @Override
-    public String getHelpText() {
-        return "Redirects users to their home identity provider";
-    }
+  @Override
+  public String getHelpText() {
+    return "Redirects users to their home identity provider";
+  }
 
-    @Override
-    public String getId() {
-        return PROVIDER_ID;
-    }
+  @Override
+  public String getId() {
+    return PROVIDER_ID;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpForwarderConfig.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpForwarderConfig.java
@@ -1,30 +1,30 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
-import org.keycloak.models.AuthenticatorConfigModel;
-
 import java.util.Optional;
+import org.keycloak.models.AuthenticatorConfigModel;
 
 final class HomeIdpForwarderConfig {
 
-    static final String BYPASS_LOGIN_PAGE = "bypassLoginPage";
-    static final String FORWARD_TO_FIRST_MATCH = "forwardToFirstMatch";
+  static final String BYPASS_LOGIN_PAGE = "bypassLoginPage";
+  static final String FORWARD_TO_FIRST_MATCH = "forwardToFirstMatch";
 
-    private final AuthenticatorConfigModel authenticatorConfigModel;
+  private final AuthenticatorConfigModel authenticatorConfigModel;
 
-    HomeIdpForwarderConfig(AuthenticatorConfigModel authenticatorConfigModel) {
-        this.authenticatorConfigModel = authenticatorConfigModel;
-    }
+  HomeIdpForwarderConfig(AuthenticatorConfigModel authenticatorConfigModel) {
+    this.authenticatorConfigModel = authenticatorConfigModel;
+  }
 
-    boolean bypassLoginPage() {
-        return Optional.ofNullable(authenticatorConfigModel)
-            .map(it -> Boolean.parseBoolean(it.getConfig().getOrDefault(BYPASS_LOGIN_PAGE, "false")))
-            .orElse(false);
-    }
+  boolean bypassLoginPage() {
+    return Optional.ofNullable(authenticatorConfigModel)
+        .map(it -> Boolean.parseBoolean(it.getConfig().getOrDefault(BYPASS_LOGIN_PAGE, "false")))
+        .orElse(false);
+  }
 
-    boolean forwardToFirstMatch() {
-        return Optional.ofNullable(authenticatorConfigModel)
-            .map(it -> Boolean.parseBoolean(it.getConfig().getOrDefault(FORWARD_TO_FIRST_MATCH, "true")))
-            .orElse(true);
-    }
+  boolean forwardToFirstMatch() {
+    return Optional.ofNullable(authenticatorConfigModel)
+        .map(
+            it -> Boolean.parseBoolean(it.getConfig().getOrDefault(FORWARD_TO_FIRST_MATCH, "true")))
+        .orElse(true);
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpForwarderConfigProperties.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpForwarderConfigProperties.java
@@ -1,35 +1,36 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
-
-import org.keycloak.provider.ProviderConfigProperty;
-import org.keycloak.provider.ProviderConfigurationBuilder;
-
-import java.util.List;
 
 import static io.phasetwo.service.auth.idp.HomeIdpForwarderConfig.BYPASS_LOGIN_PAGE;
 import static io.phasetwo.service.auth.idp.HomeIdpForwarderConfig.FORWARD_TO_FIRST_MATCH;
 import static org.keycloak.provider.ProviderConfigProperty.BOOLEAN_TYPE;
 
+import java.util.List;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
 final class HomeIdpForwarderConfigProperties {
-    private static final ProviderConfigProperty BYPASS_LOGIN_PAGE_PROPERTY = new ProviderConfigProperty(
-        BYPASS_LOGIN_PAGE,
-        "Bypass login page",
-        "If OIDC login_hint parameter is present, whether to bypass the login page for managed domains or not.",
-        BOOLEAN_TYPE,
-        false,
-        false);
+  private static final ProviderConfigProperty BYPASS_LOGIN_PAGE_PROPERTY =
+      new ProviderConfigProperty(
+          BYPASS_LOGIN_PAGE,
+          "Bypass login page",
+          "If OIDC login_hint parameter is present, whether to bypass the login page for managed domains or not.",
+          BOOLEAN_TYPE,
+          false,
+          false);
 
-    private static final ProviderConfigProperty FORWARD_TO_FIRST_MATCH_PROPERTY = new ProviderConfigProperty(
-        FORWARD_TO_FIRST_MATCH,
-        "Forward to first matched IdP",
-        "When multiple IdPs match the domain, whether to forward to the first IdP found or let the user choose.",
-        BOOLEAN_TYPE,
-        true,
-        false);
+  private static final ProviderConfigProperty FORWARD_TO_FIRST_MATCH_PROPERTY =
+      new ProviderConfigProperty(
+          FORWARD_TO_FIRST_MATCH,
+          "Forward to first matched IdP",
+          "When multiple IdPs match the domain, whether to forward to the first IdP found or let the user choose.",
+          BOOLEAN_TYPE,
+          true,
+          false);
 
-    static final List<ProviderConfigProperty> CONFIG_PROPERTIES = ProviderConfigurationBuilder.create()
-        .property(BYPASS_LOGIN_PAGE_PROPERTY)
-        .property(FORWARD_TO_FIRST_MATCH_PROPERTY)
-        .build();
-
+  static final List<ProviderConfigProperty> CONFIG_PROPERTIES =
+      ProviderConfigurationBuilder.create()
+          .property(BYPASS_LOGIN_PAGE_PROPERTY)
+          .property(FORWARD_TO_FIRST_MATCH_PROPERTY)
+          .build();
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/IdpSelectorAuthenticator.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/IdpSelectorAuthenticator.java
@@ -31,55 +31,56 @@ public class IdpSelectorAuthenticator implements Authenticator {
   }
 
   private void redirect(AuthenticationFlowContext context, String providerId) {
-    IdentityProviderModel identityProvider = context.getSession()
-            .identityProviders().getByAlias(providerId);
+    IdentityProviderModel identityProvider =
+        context.getSession().identityProviders().getByAlias(providerId);
     if (identityProvider != null && identityProvider.isEnabled()) {
       new Redirector(context).redirectTo(identityProvider);
-        /*
-        String accessCode =
-            new ClientSessionCode<>(
-                    context.getSession(), context.getRealm(), context.getAuthenticationSession())
-                .getOrGenerateCode();
-        String clientId = context.getAuthenticationSession().getClient().getClientId();
-        String tabId = context.getAuthenticationSession().getTabId();
-        URI location =
-            Urls.identityProviderAuthnRequest(
-                context.getUriInfo().getBaseUri(),
-                providerId,
-                context.getRealm().getName(),
-                accessCode,
-                clientId,
-                tabId);
-        if (context.getAuthenticationSession().getClientNote(OAuth2Constants.DISPLAY) != null) {
-          location =
-              UriBuilder.fromUri(location)
-                  .queryParam(
-                      OAuth2Constants.DISPLAY,
-                      context.getAuthenticationSession().getClientNote(OAuth2Constants.DISPLAY))
-                  .build();
-        }
-        Response response = Response.seeOther(location).build();
-        // will forward the request to the IDP with prompt=none if the IDP accepts forwards with
-        // prompt=none.
-        if ("none"
-                .equals(
-                    context
-                        .getAuthenticationSession()
-                        .getClientNote(OIDCLoginProtocol.PROMPT_PARAM))
-            && Boolean.valueOf(identityProvider.getConfig().get(ACCEPTS_PROMPT_NONE))) {
-          context
-              .getAuthenticationSession()
-              .setAuthNote(AuthenticationProcessor.FORWARDED_PASSIVE_LOGIN, "true");
-        }
+      /*
+      String accessCode =
+          new ClientSessionCode<>(
+                  context.getSession(), context.getRealm(), context.getAuthenticationSession())
+              .getOrGenerateCode();
+      String clientId = context.getAuthenticationSession().getClient().getClientId();
+      String tabId = context.getAuthenticationSession().getTabId();
+      URI location =
+          Urls.identityProviderAuthnRequest(
+              context.getUriInfo().getBaseUri(),
+              providerId,
+              context.getRealm().getName(),
+              accessCode,
+              clientId,
+              tabId);
+      if (context.getAuthenticationSession().getClientNote(OAuth2Constants.DISPLAY) != null) {
+        location =
+            UriBuilder.fromUri(location)
+                .queryParam(
+                    OAuth2Constants.DISPLAY,
+                    context.getAuthenticationSession().getClientNote(OAuth2Constants.DISPLAY))
+                .build();
+      }
+      Response response = Response.seeOther(location).build();
+      // will forward the request to the IDP with prompt=none if the IDP accepts forwards with
+      // prompt=none.
+      if ("none"
+              .equals(
+                  context
+                      .getAuthenticationSession()
+                      .getClientNote(OIDCLoginProtocol.PROMPT_PARAM))
+          && Boolean.valueOf(identityProvider.getConfig().get(ACCEPTS_PROMPT_NONE))) {
+        context
+            .getAuthenticationSession()
+            .setAuthNote(AuthenticationProcessor.FORWARDED_PASSIVE_LOGIN, "true");
+      }
 
-        log.debugf("Redirecting to %s", providerId);
-        context.forceChallenge(response);
-        */
+      log.debugf("Redirecting to %s", providerId);
+      context.forceChallenge(response);
+      */
       return;
     }
 
     log.warnf("Provider not found or not enabled for realm %s", providerId);
-    if (context.getExecution().getRequirement() == AuthenticationExecutionModel.Requirement.REQUIRED) {
+    if (context.getExecution().getRequirement()
+        == AuthenticationExecutionModel.Requirement.REQUIRED) {
       context.success();
     } else {
       context.attempted();

--- a/src/main/java/io/phasetwo/service/auth/idp/LoginForm.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/LoginForm.java
@@ -1,64 +1,60 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.util.List;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.forms.login.freemarker.model.IdentityProviderBean;
 import org.keycloak.models.IdentityProviderModel;
 
-import java.net.URI;
-import java.util.List;
-
 final class LoginForm {
 
-    private final AuthenticationFlowContext context;
-    private final BaseUriLoginFormsProvider loginFormsProvider;
+  private final AuthenticationFlowContext context;
+  private final BaseUriLoginFormsProvider loginFormsProvider;
 
-    LoginForm(AuthenticationFlowContext context, BaseUriLoginFormsProvider loginFormsProvider) {
-        this.context = context;
-        this.loginFormsProvider = loginFormsProvider;
-    }
+  LoginForm(AuthenticationFlowContext context, BaseUriLoginFormsProvider loginFormsProvider) {
+    this.context = context;
+    this.loginFormsProvider = loginFormsProvider;
+  }
 
-    Response createWithSignInButtonOnly(MultivaluedMap<String, String> formData) {
-        LoginFormsProvider form = createForm(formData);
-        form.setAttribute(LoginFormsProvider.USERNAME_HIDDEN, "true");
-        form.setAttribute(LoginFormsProvider.REGISTRATION_DISABLED, "true");
-        return form.createLoginUsername();
-    }
+  Response createWithSignInButtonOnly(MultivaluedMap<String, String> formData) {
+    LoginFormsProvider form = createForm(formData);
+    form.setAttribute(LoginFormsProvider.USERNAME_HIDDEN, "true");
+    form.setAttribute(LoginFormsProvider.REGISTRATION_DISABLED, "true");
+    return form.createLoginUsername();
+  }
 
-    Response create(MultivaluedMap<String, String> formData) {
-        LoginFormsProvider forms = createForm(formData);
-        return forms.createLoginUsername();
-    }
+  Response create(MultivaluedMap<String, String> formData) {
+    LoginFormsProvider forms = createForm(formData);
+    return forms.createLoginUsername();
+  }
 
-    private LoginFormsProvider createForm(MultivaluedMap<String, String> formData) {
-        LoginFormsProvider forms = context.form();
-        if (!formData.isEmpty()) {
-            forms.setFormData(formData);
-        }
-        return forms;
+  private LoginFormsProvider createForm(MultivaluedMap<String, String> formData) {
+    LoginFormsProvider forms = context.form();
+    if (!formData.isEmpty()) {
+      forms.setFormData(formData);
     }
+    return forms;
+  }
 
-    Response create(List<IdentityProviderModel> idps) {
-        URI baseUriWithCodeAndClientId = loginFormsProvider.getBaseUriWithCodeAndClientId();
-        LoginFormsProvider forms = context.form();
-        forms.setAttribute("hidpd", new IdentityProviderBean(
-            context.getSession(),
-            context.getRealm(),
-            baseUriWithCodeAndClientId,
-            context
-            ) {
-                @Override
-                public List<IdentityProvider> getProviders() {
-                    return idps.stream()
-                        .map(AlwaysSelectableIdentityProviderModel::new)
-                        .map(idp -> createIdentityProvider(this.realm, this.baseURI, idp))
-                        .toList();
-                }
-            }
-        );
-        return forms.createForm("hidpd-select-idp.ftl");
-    }
+  Response create(List<IdentityProviderModel> idps) {
+    URI baseUriWithCodeAndClientId = loginFormsProvider.getBaseUriWithCodeAndClientId();
+    LoginFormsProvider forms = context.form();
+    forms.setAttribute(
+        "hidpd",
+        new IdentityProviderBean(
+            context.getSession(), context.getRealm(), baseUriWithCodeAndClientId, context) {
+          @Override
+          public List<IdentityProvider> getProviders() {
+            return idps.stream()
+                .map(AlwaysSelectableIdentityProviderModel::new)
+                .map(idp -> createIdentityProvider(this.realm, this.baseURI, idp))
+                .toList();
+          }
+        });
+    return forms.createForm("hidpd-select-idp.ftl");
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/LoginHint.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/LoginHint.java
@@ -1,6 +1,10 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
+import static org.keycloak.protocol.oidc.OIDCLoginProtocol.LOGIN_HINT_PARAM;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.IdentityProviderModel;
@@ -9,48 +13,49 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.services.managers.ClientSessionCode;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static org.keycloak.protocol.oidc.OIDCLoginProtocol.LOGIN_HINT_PARAM;
-
 final class LoginHint {
 
-    private final AuthenticationFlowContext context;
-    private final Users users;
+  private final AuthenticationFlowContext context;
+  private final Users users;
 
-    LoginHint(AuthenticationFlowContext context, Users users) {
-        this.context = context;
-        this.users = users;
-    }
+  LoginHint(AuthenticationFlowContext context, Users users) {
+    this.context = context;
+    this.users = users;
+  }
 
-    void setInAuthSession(IdentityProviderModel homeIdp, String username) {
-        String loginHint = username;
-        UserModel user = users.lookupBy(username);
-        if (user != null) {
-            Map<String, String> idpToUsername = context.getSession().users()
-                .getFederatedIdentitiesStream(context.getRealm(), user)
-                .collect(
-                    Collectors.toMap(FederatedIdentityModel::getIdentityProvider,
-                        FederatedIdentityModel::getUserName));
-            String alias = homeIdp == null ? "" : homeIdp.getAlias();
-            loginHint = idpToUsername.getOrDefault(alias, username);
-        }
-        setInAuthSession(loginHint);
+  void setInAuthSession(IdentityProviderModel homeIdp, String username) {
+    String loginHint = username;
+    UserModel user = users.lookupBy(username);
+    if (user != null) {
+      Map<String, String> idpToUsername =
+          context
+              .getSession()
+              .users()
+              .getFederatedIdentitiesStream(context.getRealm(), user)
+              .collect(
+                  Collectors.toMap(
+                      FederatedIdentityModel::getIdentityProvider,
+                      FederatedIdentityModel::getUserName));
+      String alias = homeIdp == null ? "" : homeIdp.getAlias();
+      loginHint = idpToUsername.getOrDefault(alias, username);
     }
+    setInAuthSession(loginHint);
+  }
 
-    void setInAuthSession(String loginHint) {
-        context.getAuthenticationSession().setClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM, loginHint);
-    }
+  void setInAuthSession(String loginHint) {
+    context.getAuthenticationSession().setClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM, loginHint);
+  }
 
-    String getFromSession() {
-        return context.getAuthenticationSession().getClientNote(LOGIN_HINT_PARAM);
-    }
+  String getFromSession() {
+    return context.getAuthenticationSession().getClientNote(LOGIN_HINT_PARAM);
+  }
 
-    void copyTo(ClientSessionCode<AuthenticationSessionModel> clientSessionCode) {
-        String loginHint = getFromSession();
-        if (clientSessionCode.getClientSession() != null && loginHint != null) {
-            clientSessionCode.getClientSession().setClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM, loginHint);
-        }
+  void copyTo(ClientSessionCode<AuthenticationSessionModel> clientSessionCode) {
+    String loginHint = getFromSession();
+    if (clientSessionCode.getClientSession() != null && loginHint != null) {
+      clientSessionCode
+          .getClientSession()
+          .setClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM, loginHint);
     }
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/LoginPage.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/LoginPage.java
@@ -1,52 +1,54 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
-
-import org.jboss.logging.Logger;
-import org.keycloak.authentication.AuthenticationFlowContext;
-import org.keycloak.sessions.AuthenticationSessionModel;
-import org.keycloak.util.TokenUtil;
-
-import java.util.Set;
 
 import static org.keycloak.protocol.oidc.OIDCLoginProtocol.*;
 import static org.keycloak.protocol.saml.SamlProtocol.SAML_FORCEAUTHN_REQUIREMENT;
 import static org.keycloak.protocol.saml.SamlProtocol.SAML_LOGIN_REQUEST_FORCEAUTHN;
 
+import java.util.Set;
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.util.TokenUtil;
+
 final class LoginPage {
 
-    private static final Logger LOG = Logger.getLogger(LoginPage.class);
-    private static final Set<String> OIDC_PROMPT_NO_BYPASS =
-        Set.of(PROMPT_VALUE_LOGIN, PROMPT_VALUE_CONSENT, PROMPT_VALUE_SELECT_ACCOUNT);
+  private static final Logger LOG = Logger.getLogger(LoginPage.class);
+  private static final Set<String> OIDC_PROMPT_NO_BYPASS =
+      Set.of(PROMPT_VALUE_LOGIN, PROMPT_VALUE_CONSENT, PROMPT_VALUE_SELECT_ACCOUNT);
 
-    private final AuthenticationFlowContext context;
-    private final HomeIdpForwarderConfig config;
-    private final Reauthentication reauthentication;
+  private final AuthenticationFlowContext context;
+  private final HomeIdpForwarderConfig config;
+  private final Reauthentication reauthentication;
 
-    LoginPage(AuthenticationFlowContext context, HomeIdpForwarderConfig config, Reauthentication reauthentication) {
-        this.context = context;
-        this.config = config;
-        this.reauthentication = reauthentication;
+  LoginPage(
+      AuthenticationFlowContext context,
+      HomeIdpForwarderConfig config,
+      Reauthentication reauthentication) {
+    this.context = context;
+    this.config = config;
+    this.reauthentication = reauthentication;
+  }
+
+  boolean shouldByPass() {
+    boolean bypassLoginPage = config.bypassLoginPage();
+    if (bypassLoginPage) {
+      AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
+      String prompt = authenticationSession.getClientNote(PROMPT_PARAM);
+      if (OIDC_PROMPT_NO_BYPASS.stream().anyMatch(it -> TokenUtil.hasPrompt(prompt, it))) {
+        LOG.debugf("OIDC: Forced by prompt=%s", prompt);
+        return false;
+      }
+      if (SAML_FORCEAUTHN_REQUIREMENT.equalsIgnoreCase(
+          authenticationSession.getAuthNote(SAML_LOGIN_REQUEST_FORCEAUTHN))) {
+        LOG.debugf("SAML: Forced authentication");
+        return false;
+      }
+      if (reauthentication.required()) {
+        LOG.debugf("Forced, cause reauthentication is required");
+        return false;
+      }
     }
-
-    boolean shouldByPass() {
-        boolean bypassLoginPage = config.bypassLoginPage();
-        if (bypassLoginPage) {
-            AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
-            String prompt = authenticationSession.getClientNote(PROMPT_PARAM);
-            if (OIDC_PROMPT_NO_BYPASS.stream().anyMatch(it -> TokenUtil.hasPrompt(prompt, it))) {
-                LOG.debugf("OIDC: Forced by prompt=%s", prompt);
-                return false;
-            }
-            if (SAML_FORCEAUTHN_REQUIREMENT.equalsIgnoreCase(
-                authenticationSession.getAuthNote(SAML_LOGIN_REQUEST_FORCEAUTHN))) {
-                LOG.debugf("SAML: Forced authentication");
-                return false;
-            }
-            if (reauthentication.required()) {
-                LOG.debugf("Forced, cause reauthentication is required");
-                return false;
-            }
-        }
-        return bypassLoginPage;
-    }
+    return bypassLoginPage;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/OperationalInfo.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/OperationalInfo.java
@@ -1,16 +1,15 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
 import java.util.Map;
 
 public final class OperationalInfo {
 
-    public static Map<String, String> get() {
-        String version = OperationalInfo.class.getPackage().getImplementationVersion();
-        if (version == null) {
-            version = "dev-snapshot";
-        }
-        return Map.of("Version", version);
+  public static Map<String, String> get() {
+    String version = OperationalInfo.class.getPackage().getImplementationVersion();
+    if (version == null) {
+      version = "dev-snapshot";
     }
-
+    return Map.of("Version", version);
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/PublicAPI.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/PublicAPI.java
@@ -1,49 +1,46 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
 import java.lang.annotation.*;
 
-
 /**
- * Marks a class or method as part of the public API of this extension. This annotation
- * serves to clearly indicate which components of the extension are designed for external
- * use and are supported according to the project's compatibility and deprecation policies.
+ * Marks a class or method as part of the public API of this extension. This annotation serves to
+ * clearly indicate which components of the extension are designed for external use and are
+ * supported according to the project's compatibility and deprecation policies.
  *
  * <p>Elements marked with this annotation are considered stable and safe for use in production
- * environments, unless specified otherwise by the {@code unstable} attribute. Developers
- * using these APIs can expect them to follow semantically versioned paths for updates,
- * including deprecations and removals.</p>
+ * environments, unless specified otherwise by the {@code unstable} attribute. Developers using
+ * these APIs can expect them to follow semantically versioned paths for updates, including
+ * deprecations and removals.
  *
  * <h2>Usage Guidelines</h2>
+ *
  * <ul>
- *   <li><strong>Stable API:</strong> By default, APIs annotated with {@code @PublicAPI} without
- *   the {@code unstable} flag set to {@code true} are stable. These APIs are suitable for
- *   long-term use and should maintain backward compatibility according to the project's versioning
- *   policy.</li>
- *   <li><strong>Unstable API:</strong> APIs marked as unstable with {@code @PublicAPI(unstable = true)}
- *   are in a state of flux and may undergo significant changes including backwards incompatible
- *   modifications. They are intended for testing, experimental use, or to gain feedback before
- *   becoming part of the stable public API.</li>
+ *   <li><strong>Stable API:</strong> By default, APIs annotated with {@code @PublicAPI} without the
+ *       {@code unstable} flag set to {@code true} are stable. These APIs are suitable for long-term
+ *       use and should maintain backward compatibility according to the project's versioning
+ *       policy.
+ *   <li><strong>Unstable API:</strong> APIs marked as unstable with {@code @PublicAPI(unstable =
+ *       true)} are in a state of flux and may undergo significant changes including backwards
+ *       incompatible modifications. They are intended for testing, experimental use, or to gain
+ *       feedback before becoming part of the stable public API.
  * </ul>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR})
 public @interface PublicAPI {
-    /**
-     * Indicates whether this API is unstable. Unstable APIs are subject to change
-     * and may not maintain backward compatibility. Default is {@code false}, indicating
-     * the API is stable and intended for widespread use in production environments.
-     * <p>
-     * Unstable APIs are intended for early
-     * access to features for feedback and may change based on that feedback or
-     * be removed in future versions.
-     * </p>
-     * <p>
-     * Default value: {@code false}, meaning the API is stable.
-     * </p>
-     *
-     * @return {@code true} if the API is unstable, {@code false} if it is stable.
-     */
-    boolean unstable() default false;
+  /**
+   * Indicates whether this API is unstable. Unstable APIs are subject to change and may not
+   * maintain backward compatibility. Default is {@code false}, indicating the API is stable and
+   * intended for widespread use in production environments.
+   *
+   * <p>Unstable APIs are intended for early access to features for feedback and may change based on
+   * that feedback or be removed in future versions.
+   *
+   * <p>Default value: {@code false}, meaning the API is stable.
+   *
+   * @return {@code true} if the API is unstable, {@code false} if it is stable.
+   */
+  boolean unstable() default false;
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/Reauthentication.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/Reauthentication.java
@@ -1,4 +1,4 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -8,19 +8,24 @@ import org.keycloak.services.managers.AuthenticationManager;
 
 final class Reauthentication {
 
-    private final AuthenticationFlowContext context;
+  private final AuthenticationFlowContext context;
 
-    Reauthentication(AuthenticationFlowContext context) {
-        this.context = context;
-    }
+  Reauthentication(AuthenticationFlowContext context) {
+    this.context = context;
+  }
 
-    boolean required() {
-        AuthenticationManager.AuthResult authResult = AuthenticationManager.authenticateIdentityCookie(context.getSession(), context.getRealm(), true);
-        UserSessionModel userSessionModel = null;
-        if (authResult != null) {
-            userSessionModel = authResult.session();
-        }
-        LoginProtocol protocol = context.getSession().getProvider(LoginProtocol.class, context.getAuthenticationSession().getProtocol());
-        return protocol.requireReauthentication(userSessionModel, context.getAuthenticationSession());
+  boolean required() {
+    AuthenticationManager.AuthResult authResult =
+        AuthenticationManager.authenticateIdentityCookie(
+            context.getSession(), context.getRealm(), true);
+    UserSessionModel userSessionModel = null;
+    if (authResult != null) {
+      userSessionModel = authResult.session();
     }
+    LoginProtocol protocol =
+        context
+            .getSession()
+            .getProvider(LoginProtocol.class, context.getAuthenticationSession().getProtocol());
+    return protocol.requireReauthentication(userSessionModel, context.getAuthenticationSession());
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/Redirector.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/Redirector.java
@@ -1,13 +1,13 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
+
+import static org.keycloak.services.resources.IdentityBrokerService.getIdentityProvider;
 
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.broker.provider.AuthenticationRequest;
-import org.keycloak.broker.provider.IdentityProvider;
-import org.keycloak.broker.provider.IdentityProviderFactory;
 import org.keycloak.broker.provider.UserAuthenticationIdentityProvider;
 import org.keycloak.broker.provider.util.IdentityBrokerState;
 import org.keycloak.models.IdentityProviderModel;
@@ -19,57 +19,79 @@ import org.keycloak.services.managers.ClientSessionCode;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.Booleans;
 
-import static org.keycloak.services.resources.IdentityBrokerService.getIdentityProvider;
-
 final class Redirector {
 
-    private static final Logger LOG = Logger.getLogger(Redirector.class);
+  private static final Logger LOG = Logger.getLogger(Redirector.class);
 
-    private final AuthenticationFlowContext context;
+  private final AuthenticationFlowContext context;
 
-    Redirector(AuthenticationFlowContext context) {
-        this.context = context;
+  Redirector(AuthenticationFlowContext context) {
+    this.context = context;
+  }
+
+  void redirectTo(IdentityProviderModel idp) {
+    String providerAlias = idp.getAlias();
+    RealmModel realm = context.getRealm();
+    AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
+    KeycloakSession keycloakSession = context.getSession();
+    ClientSessionCode<AuthenticationSessionModel> clientSessionCode =
+        new ClientSessionCode<>(keycloakSession, realm, authenticationSession);
+    clientSessionCode.setAction(AuthenticationSessionModel.Action.AUTHENTICATE.name());
+    if (!idp.isEnabled()) {
+      LOG.warnf("Identity Provider %s is disabled.", providerAlias);
+      return;
+    }
+    if (Booleans.isTrue(idp.isLinkOnly())) {
+      LOG.warnf("Identity Provider %s is not allowed to perform a login.", providerAlias);
+      return;
+    }
+    new HomeIdpAuthenticationFlowContext(context).loginHint().copyTo(clientSessionCode);
+    UserAuthenticationIdentityProvider<?> identityProvider =
+        getIdentityProvider(keycloakSession, idp.getAlias());
+
+    Response response =
+        identityProvider.performLogin(
+            createAuthenticationRequest(providerAlias, identityProvider, clientSessionCode));
+    context.forceChallenge(response);
+  }
+
+  private AuthenticationRequest createAuthenticationRequest(
+      String providerAlias,
+      UserAuthenticationIdentityProvider<?> identityProvider,
+      ClientSessionCode<AuthenticationSessionModel> clientSessionCode) {
+    AuthenticationSessionModel authSession = null;
+    IdentityBrokerState encodedState = null;
+
+    if (clientSessionCode != null) {
+      authSession = clientSessionCode.getClientSession();
+      String relayState = clientSessionCode.getOrGenerateCode();
+      String clientData =
+          identityProvider.supportsLongStateParameter()
+              ? AuthenticationProcessor.getClientData(context.getSession(), authSession)
+              : null;
+      encodedState =
+          IdentityBrokerState.decoded(
+              relayState,
+              authSession.getClient().getId(),
+              authSession.getClient().getClientId(),
+              authSession.getTabId(),
+              clientData);
     }
 
-    void redirectTo(IdentityProviderModel idp) {
-        String providerAlias = idp.getAlias();
-        RealmModel realm = context.getRealm();
-        AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
-        KeycloakSession keycloakSession = context.getSession();
-        ClientSessionCode<AuthenticationSessionModel> clientSessionCode =
-            new ClientSessionCode<>(keycloakSession, realm, authenticationSession);
-        clientSessionCode.setAction(AuthenticationSessionModel.Action.AUTHENTICATE.name());
-        if (!idp.isEnabled()) {
-            LOG.warnf("Identity Provider %s is disabled.", providerAlias);
-            return;
-        }
-        if (Booleans.isTrue(idp.isLinkOnly())) {
-            LOG.warnf("Identity Provider %s is not allowed to perform a login.", providerAlias);
-            return;
-        }
-        new HomeIdpAuthenticationFlowContext(context).loginHint().copyTo(clientSessionCode);
-        UserAuthenticationIdentityProvider<?> identityProvider = getIdentityProvider(keycloakSession, idp.getAlias());
-
-        Response response = identityProvider.performLogin(createAuthenticationRequest(providerAlias, identityProvider, clientSessionCode));
-        context.forceChallenge(response);
-    }
-
-    private AuthenticationRequest createAuthenticationRequest(String providerAlias, UserAuthenticationIdentityProvider<?> identityProvider, ClientSessionCode<AuthenticationSessionModel> clientSessionCode) {
-        AuthenticationSessionModel authSession = null;
-        IdentityBrokerState encodedState = null;
-
-        if (clientSessionCode != null) {
-            authSession = clientSessionCode.getClientSession();
-            String relayState = clientSessionCode.getOrGenerateCode();
-            String clientData = identityProvider.supportsLongStateParameter() ? AuthenticationProcessor.getClientData(context.getSession(), authSession) : null;
-            encodedState = IdentityBrokerState.decoded(relayState, authSession.getClient().getId(), authSession.getClient().getClientId(), authSession.getTabId(), clientData);
-        }
-
-        KeycloakSession keycloakSession = context.getSession();
-        KeycloakUriInfo keycloakUriInfo = keycloakSession.getContext().getUri();
-        RealmModel realm = context.getRealm();
-        String redirectUri = Urls.identityProviderAuthnResponse(keycloakUriInfo.getBaseUri(), providerAlias, realm.getName()).toString();
-        return new AuthenticationRequest(keycloakSession, realm, authSession, context.getHttpRequest(), keycloakUriInfo, encodedState, redirectUri);
-    }
-
+    KeycloakSession keycloakSession = context.getSession();
+    KeycloakUriInfo keycloakUriInfo = keycloakSession.getContext().getUri();
+    RealmModel realm = context.getRealm();
+    String redirectUri =
+        Urls.identityProviderAuthnResponse(
+                keycloakUriInfo.getBaseUri(), providerAlias, realm.getName())
+            .toString();
+    return new AuthenticationRequest(
+        keycloakSession,
+        realm,
+        authSession,
+        context.getHttpRequest(),
+        keycloakUriInfo,
+        encodedState,
+        redirectUri);
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/RememberMe.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/RememberMe.java
@@ -1,4 +1,4 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -9,38 +9,39 @@ import org.keycloak.services.managers.AuthenticationManager;
 
 final class RememberMe {
 
-    private final AuthenticationFlowContext context;
+  private final AuthenticationFlowContext context;
 
-    RememberMe(AuthenticationFlowContext context) {
-        this.context = context;
-    }
+  RememberMe(AuthenticationFlowContext context) {
+    this.context = context;
+  }
 
-    void remember(String username) {
-        String rememberMe = context.getAuthenticationSession().getAuthNote(Details.REMEMBER_ME);
-        RealmModel realm = context.getRealm();
-        boolean remember = realm.isRememberMe() && "true".equalsIgnoreCase(rememberMe);
-        if (remember) {
-            AuthenticationManager.createRememberMeCookie(username, context.getUriInfo(), context.getSession());
-        } else {
-            AuthenticationManager.expireRememberMeCookie(context.getSession());
-        }
+  void remember(String username) {
+    String rememberMe = context.getAuthenticationSession().getAuthNote(Details.REMEMBER_ME);
+    RealmModel realm = context.getRealm();
+    boolean remember = realm.isRememberMe() && "true".equalsIgnoreCase(rememberMe);
+    if (remember) {
+      AuthenticationManager.createRememberMeCookie(
+          username, context.getUriInfo(), context.getSession());
+    } else {
+      AuthenticationManager.expireRememberMeCookie(context.getSession());
     }
+  }
 
-    /*
-     * Sets session notes for interoperability with other authenticators and Keycloak defaults
-     */
-    void handleAction(MultivaluedMap<String, String> formData) {
-        boolean remember = context.getRealm().isRememberMe() &&
-            "on".equalsIgnoreCase(formData.getFirst("rememberMe"));
-        if (remember) {
-            context.getAuthenticationSession().setAuthNote(Details.REMEMBER_ME, "true");
-            context.getEvent().detail(Details.REMEMBER_ME, "true");
-        } else {
-            context.getAuthenticationSession().removeAuthNote(Details.REMEMBER_ME);
-        }
+  /*
+   * Sets session notes for interoperability with other authenticators and Keycloak defaults
+   */
+  void handleAction(MultivaluedMap<String, String> formData) {
+    boolean remember =
+        context.getRealm().isRememberMe() && "on".equalsIgnoreCase(formData.getFirst("rememberMe"));
+    if (remember) {
+      context.getAuthenticationSession().setAuthNote(Details.REMEMBER_ME, "true");
+      context.getEvent().detail(Details.REMEMBER_ME, "true");
+    } else {
+      context.getAuthenticationSession().removeAuthNote(Details.REMEMBER_ME);
     }
+  }
 
-    String getUserName() {
-        return AuthenticationManager.getRememberMeUsername(context.getSession());
-    }
+  String getUserName() {
+    return AuthenticationManager.getRememberMeUsername(context.getSession());
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/Users.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/Users.java
@@ -1,4 +1,4 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp;
 
 import org.jboss.logging.Logger;
@@ -9,22 +9,26 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 
 public final class Users {
 
-    private static final Logger LOG = Logger.getLogger(Users.class);
+  private static final Logger LOG = Logger.getLogger(Users.class);
 
-    private final KeycloakSession keycloakSession;
+  private final KeycloakSession keycloakSession;
 
-    public Users(KeycloakSession keycloakSession) {
-        this.keycloakSession = keycloakSession;
+  public Users(KeycloakSession keycloakSession) {
+    this.keycloakSession = keycloakSession;
+  }
+
+  public UserModel lookupBy(String username) {
+    UserModel user = null;
+    try {
+      user =
+          KeycloakModelUtils.findUserByNameOrEmail(
+              keycloakSession, keycloakSession.getContext().getRealm(), username);
+    } catch (ModelDuplicateException ex) {
+      LOG.warnf(
+          ex,
+          "Could not uniquely identify the user. Multiple users with name or email '%s' found.",
+          username);
     }
-
-    public UserModel lookupBy(String username) {
-        UserModel user = null;
-        try {
-            user = KeycloakModelUtils.findUserByNameOrEmail(keycloakSession, keycloakSession.getContext().getRealm(), username);
-        } catch (ModelDuplicateException ex) {
-            LOG.warnf(ex, "Could not uniquely identify the user. Multiple users with name or email '%s' found.", username);
-        }
-        return user;
-    }
-
+    return user;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/DefaultIdentityProviders.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/DefaultIdentityProviders.java
@@ -1,23 +1,30 @@
 package io.phasetwo.service.auth.idp.discovery.extattribute;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.IdentityProviderModel;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 final class DefaultIdentityProviders implements IdentityProviders {
 
-    @Override
-    public List<IdentityProviderModel> withMatchingAttribute(AuthenticationFlowContext context, List<IdentityProviderModel> candidates, String attribute) {
-        UserAttributeHomeIdpDiscovererConfig config = new UserAttributeHomeIdpDiscovererConfig(context.getAuthenticatorConfig());
-        String userAttributeName = config.userAttribute();
+  @Override
+  public List<IdentityProviderModel> withMatchingAttribute(
+      AuthenticationFlowContext context, List<IdentityProviderModel> candidates, String attribute) {
+    UserAttributeHomeIdpDiscovererConfig config =
+        new UserAttributeHomeIdpDiscovererConfig(context.getAuthenticatorConfig());
+    String userAttributeName = config.userAttribute();
 
-        List<IdentityProviderModel> idpsWithMatchingDomain = candidates.stream()
-                .filter(it -> new IdentityProviderModelConfig(it).supportsAttribute(attribute))
-                .collect(Collectors.toList());
-        LOG.tracef("IdPs with matching attribute '%s' for attribute '%s': %s", userAttributeName, attribute,
-                idpsWithMatchingDomain.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(",")));
-        return idpsWithMatchingDomain;
-    }
+    List<IdentityProviderModel> idpsWithMatchingDomain =
+        candidates.stream()
+            .filter(it -> new IdentityProviderModelConfig(it).supportsAttribute(attribute))
+            .collect(Collectors.toList());
+    LOG.tracef(
+        "IdPs with matching attribute '%s' for attribute '%s': %s",
+        userAttributeName,
+        attribute,
+        idpsWithMatchingDomain.stream()
+            .map(IdentityProviderModel::getAlias)
+            .collect(Collectors.joining(",")));
+    return idpsWithMatchingDomain;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/IdentityProviderModelConfig.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/IdentityProviderModelConfig.java
@@ -1,30 +1,29 @@
 package io.phasetwo.service.auth.idp.discovery.extattribute;
 
+import static io.phasetwo.service.auth.idp.discovery.extattribute.IdentityProviders.USER_ATTRIBUTE_KEY;
+
+import java.util.Arrays;
 import org.keycloak.models.Constants;
 import org.keycloak.models.IdentityProviderModel;
 
-import java.util.Arrays;
-
-import static io.phasetwo.service.auth.idp.discovery.extattribute.IdentityProviders.USER_ATTRIBUTE_KEY;
-
 final class IdentityProviderModelConfig {
 
-    private final IdentityProviderModel identityProviderModel;
+  private final IdentityProviderModel identityProviderModel;
 
-    IdentityProviderModelConfig(IdentityProviderModel identityProviderModel) {
-        this.identityProviderModel = identityProviderModel;
+  IdentityProviderModelConfig(IdentityProviderModel identityProviderModel) {
+    this.identityProviderModel = identityProviderModel;
+  }
+
+  boolean supportsAttribute(String att) {
+    String userAttributeValue = getUserAttributeConfigKey();
+    return Arrays.asList(Constants.CFG_DELIMITER_PATTERN.split(userAttributeValue)).contains(att);
+  }
+
+  private String getUserAttributeConfigKey() {
+    if (identityProviderModel.getConfig().containsKey(USER_ATTRIBUTE_KEY)) {
+      return identityProviderModel.getConfig().get(USER_ATTRIBUTE_KEY);
     }
 
-    boolean supportsAttribute(String att) {
-        String userAttributeValue = getUserAttributeConfigKey();
-        return Arrays.asList(Constants.CFG_DELIMITER_PATTERN.split(userAttributeValue)).contains(att);
-    }
-
-    private String getUserAttributeConfigKey() {
-        if (identityProviderModel.getConfig().containsKey(USER_ATTRIBUTE_KEY)) {
-           return identityProviderModel.getConfig().get(USER_ATTRIBUTE_KEY);
-        }
-
-        return "";
-    }
+    return "";
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/IdentityProviders.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/IdentityProviders.java
@@ -1,66 +1,68 @@
 package io.phasetwo.service.auth.idp.discovery.extattribute;
 
 import io.phasetwo.service.auth.idp.PublicAPI;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 /**
  * Defines the contract for filtering and retrieving identity providers based on domain-specific
- * criteria within the authentication process. This interface allows for the dynamic
- * selection of identity providers (IdPs) that match certain conditions, enhancing the flexibility
- * and precision of home IdP discovery mechanisms.
- * <p>
- * Implementations of this interface should provide logic to filter identity providers based on
- * custom criteria such as the domain associated with the user or other relevant factors.
- * </p>
+ * criteria within the authentication process. This interface allows for the dynamic selection of
+ * identity providers (IdPs) that match certain conditions, enhancing the flexibility and precision
+ * of home IdP discovery mechanisms.
  *
- * to changes in future releases.
+ * <p>Implementations of this interface should provide logic to filter identity providers based on
+ * custom criteria such as the domain associated with the user or other relevant factors. to changes
+ * in future releases.
  */
 @PublicAPI(unstable = true)
 public interface IdentityProviders {
 
-    Logger LOG = Logger.getLogger(IdentityProviders.class);
+  Logger LOG = Logger.getLogger(IdentityProviders.class);
 
-    public static final String USER_ATTRIBUTE_KEY = "home.idp.discovery.user-attributes";
+  public static final String USER_ATTRIBUTE_KEY = "home.idp.discovery.user-attributes";
 
-    /**
-     * Filters the given list of identity provider candidates to return those that match a specified
-     * attribute within the context of an authentication flow.
-     *
-     * @param context The authentication flow context providing runtime information about the
-     *                current authentication process.
-     * @param candidates A list of potentially eligible identity providers that may be suitable
-     *                   for the user based on initial criteria (see {@code #candidatesForHomeIdp}).
-     * @param attribute The attibute criteria used to match identity providers.
-     * @return A filtered list of {@link IdentityProviderModel} that match the specified domain criteria.
-     * May be empty but not {@code null}.
-     */
-    List<IdentityProviderModel> withMatchingAttribute(AuthenticationFlowContext context, List<IdentityProviderModel> candidates, String attribute);
+  /**
+   * Filters the given list of identity provider candidates to return those that match a specified
+   * attribute within the context of an authentication flow.
+   *
+   * @param context The authentication flow context providing runtime information about the current
+   *     authentication process.
+   * @param candidates A list of potentially eligible identity providers that may be suitable for
+   *     the user based on initial criteria (see {@code #candidatesForHomeIdp}).
+   * @param attribute The attibute criteria used to match identity providers.
+   * @return A filtered list of {@link IdentityProviderModel} that match the specified domain
+   *     criteria. May be empty but not {@code null}.
+   */
+  List<IdentityProviderModel> withMatchingAttribute(
+      AuthenticationFlowContext context, List<IdentityProviderModel> candidates, String attribute);
 
-    /**
-     * Retrieves a list of identity providers that are candidates for being the user's home IdP.
-     * <p>
-     * This default method filters out and collects only those providers that are enabled.
-     *</p>
-     * @param context The authentication flow context providing runtime information about the
-     *                current authentication process.
-     * @return A list of {@link IdentityProviderModel} from the realm. May be empty but not {@code null}.
-     */
-    default List<IdentityProviderModel> candidatesForHomeIdp(AuthenticationFlowContext context, UserModel user) {
-        RealmModel realm = context.getRealm();
-        List<IdentityProviderModel> enabledIdps = realm.getIdentityProvidersStream()
+  /**
+   * Retrieves a list of identity providers that are candidates for being the user's home IdP.
+   *
+   * <p>This default method filters out and collects only those providers that are enabled.
+   *
+   * @param context The authentication flow context providing runtime information about the current
+   *     authentication process.
+   * @return A list of {@link IdentityProviderModel} from the realm. May be empty but not {@code
+   *     null}.
+   */
+  default List<IdentityProviderModel> candidatesForHomeIdp(
+      AuthenticationFlowContext context, UserModel user) {
+    RealmModel realm = context.getRealm();
+    List<IdentityProviderModel> enabledIdps =
+        realm
+            .getIdentityProvidersStream()
             .filter(IdentityProviderModel::isEnabled)
             .collect(Collectors.toList());
-        LOG.tracef("Enabled IdPs in realm '%s': %s",
-            realm.getName(),
-            enabledIdps.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(",")));
-        return enabledIdps;
-    }
-
+    LOG.tracef(
+        "Enabled IdPs in realm '%s': %s",
+        realm.getName(),
+        enabledIdps.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(",")));
+    return enabledIdps;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/UserAttributeHomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/UserAttributeHomeIdpDiscoverer.java
@@ -1,133 +1,154 @@
 package io.phasetwo.service.auth.idp.discovery.extattribute;
 
+import static java.util.Collections.emptyList;
+
 import io.phasetwo.service.auth.idp.PublicAPI;
 import io.phasetwo.service.auth.idp.Users;
 import io.phasetwo.service.auth.idp.discovery.spi.HomeIdpDiscoverer;
+import java.util.*;
+import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.*;
 import org.keycloak.utils.StringUtil;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static java.util.Collections.emptyList;
-
 @PublicAPI(unstable = true)
 public final class UserAttributeHomeIdpDiscoverer implements HomeIdpDiscoverer {
 
-    private static final Logger LOG = Logger.getLogger(UserAttributeHomeIdpDiscoverer.class);
+  private static final Logger LOG = Logger.getLogger(UserAttributeHomeIdpDiscoverer.class);
 
-    private final Users users;
-    private final IdentityProviders identityProviders;
+  private final Users users;
+  private final IdentityProviders identityProviders;
 
-    @PublicAPI(unstable = true)
-    public UserAttributeHomeIdpDiscoverer(Users users, IdentityProviders identityProviders) {
-        this.users = users;
-        this.identityProviders = identityProviders;
+  @PublicAPI(unstable = true)
+  public UserAttributeHomeIdpDiscoverer(Users users, IdentityProviders identityProviders) {
+    this.users = users;
+    this.identityProviders = identityProviders;
+  }
+
+  @Override
+  public List<IdentityProviderModel> discoverForUser(
+      AuthenticationFlowContext context, String username) {
+    UserAttributeHomeIdpDiscovererConfig config =
+        new UserAttributeHomeIdpDiscovererConfig(context.getAuthenticatorConfig());
+
+    String realmName = context.getRealm().getName();
+    LOG.tracef(
+        "Trying to discover home IdP for username '%s' in realm '%s' with authenticator config '%s'",
+        username, realmName, config.getAlias());
+
+    List<IdentityProviderModel> homeIdps = new ArrayList<>();
+
+    UserModel user = users.lookupBy(username);
+    String attribute;
+    if (user == null) {
+      LOG.tracef(
+          "No user found in AuthenticationFlowContext. Extracting domain from provided username '%s'.",
+          username);
+      return List.of();
+    } else {
+      LOG.tracef(
+          "User found in AuthenticationFlowContext. Extracting attribute from stored user '%s'.",
+          user.getId());
+      var userAttributeName = config.userAttribute();
+      attribute = user.getFirstAttribute(userAttributeName);
     }
 
-    @Override
-    public List<IdentityProviderModel> discoverForUser(AuthenticationFlowContext context, String username) {
-        UserAttributeHomeIdpDiscovererConfig config = new UserAttributeHomeIdpDiscovererConfig(context.getAuthenticatorConfig());
-
-        String realmName = context.getRealm().getName();
-        LOG.tracef("Trying to discover home IdP for username '%s' in realm '%s' with authenticator config '%s'",
-                username, realmName, config.getAlias());
-
-        List<IdentityProviderModel> homeIdps = new ArrayList<>();
-
-        UserModel user = users.lookupBy(username);
-        String attribute;
-        if (user == null) {
-            LOG.tracef("No user found in AuthenticationFlowContext. Extracting domain from provided username '%s'.",
-                    username);
-            return List.of();
-        } else {
-            LOG.tracef("User found in AuthenticationFlowContext. Extracting attribute from stored user '%s'.",
-                    user.getId());
-            var userAttributeName = config.userAttribute();
-            attribute = user.getFirstAttribute(userAttributeName);
-        }
-
-        if (!StringUtil.isNullOrEmpty(attribute)) {
-            homeIdps = discoverHomeIdps(context, attribute, user, username);
-            if (homeIdps.isEmpty()) {
-                LOG.infof("Could not find home IdP for attribute '%s' and user '%s' in realm '%s'",
-                        attribute, username, realmName);
-            }
-        } else {
-            LOG.warnf("Could not extract attribute '%s'", username);
-        }
-
-        return homeIdps;
+    if (!StringUtil.isNullOrEmpty(attribute)) {
+      homeIdps = discoverHomeIdps(context, attribute, user, username);
+      if (homeIdps.isEmpty()) {
+        LOG.infof(
+            "Could not find home IdP for attribute '%s' and user '%s' in realm '%s'",
+            attribute, username, realmName);
+      }
+    } else {
+      LOG.warnf("Could not extract attribute '%s'", username);
     }
 
-    private List<IdentityProviderModel> discoverHomeIdps(AuthenticationFlowContext context, String attribute, UserModel user, String username) {
-        final Map<String, String> linkedIdps;
+    return homeIdps;
+  }
 
-        UserAttributeHomeIdpDiscovererConfig config = new UserAttributeHomeIdpDiscovererConfig(context.getAuthenticatorConfig());
-        if (user == null || !config.forwardToLinkedIdp()) {
-            linkedIdps = Collections.emptyMap();
-            LOG.tracef(
-                    "User '%s' is not stored locally or forwarding to linked IdP is disabled. Skipping discovery of linked IdPs.",
-                    username);
-        } else {
-            LOG.tracef(
-                    "Found local user '%s' and forwarding to linked IdP is enabled. Discovering linked IdPs.",
-                    username);
-            linkedIdps = context.getSession().users()
-                    .getFederatedIdentitiesStream(context.getRealm(), user)
-                    .collect(
-                            Collectors.toMap(FederatedIdentityModel::getIdentityProvider, FederatedIdentityModel::getUserName));
-        }
+  private List<IdentityProviderModel> discoverHomeIdps(
+      AuthenticationFlowContext context, String attribute, UserModel user, String username) {
+    final Map<String, String> linkedIdps;
 
-        List<IdentityProviderModel> candidateIdps = identityProviders.candidatesForHomeIdp(context, user);
-        if (candidateIdps == null) {
-            candidateIdps = emptyList();
-        }
-        List<IdentityProviderModel> idpsWithMatchingDomain = identityProviders.withMatchingAttribute(context, candidateIdps, attribute);
-        if (idpsWithMatchingDomain == null) {
-            idpsWithMatchingDomain = emptyList();
-        }
-
-        // Prefer linked IdP with matching domain first
-        List<IdentityProviderModel> homeIdps = getLinkedIdpsFrom(idpsWithMatchingDomain, linkedIdps);
-
-        if (homeIdps.isEmpty()) {
-            if (!linkedIdps.isEmpty()) {
-                // Prefer linked and enabled IdPs without matching domain in favor of not linked IdPs with matching domain
-                homeIdps = getLinkedIdpsFrom(candidateIdps, linkedIdps);
-            }
-            if (homeIdps.isEmpty()) {
-                // Fallback to not linked IdPs with matching domain (general case if user logs in for the first time)
-                homeIdps = idpsWithMatchingDomain;
-                logFoundIdps("non-linked", "matching", homeIdps, attribute, username);
-            } else {
-                logFoundIdps("non-linked", "non-matching", homeIdps, attribute, username);
-            }
-        } else {
-            logFoundIdps("linked", "matching", homeIdps, attribute, username);
-        }
-
-        return homeIdps;
+    UserAttributeHomeIdpDiscovererConfig config =
+        new UserAttributeHomeIdpDiscovererConfig(context.getAuthenticatorConfig());
+    if (user == null || !config.forwardToLinkedIdp()) {
+      linkedIdps = Collections.emptyMap();
+      LOG.tracef(
+          "User '%s' is not stored locally or forwarding to linked IdP is disabled. Skipping discovery of linked IdPs.",
+          username);
+    } else {
+      LOG.tracef(
+          "Found local user '%s' and forwarding to linked IdP is enabled. Discovering linked IdPs.",
+          username);
+      linkedIdps =
+          context
+              .getSession()
+              .users()
+              .getFederatedIdentitiesStream(context.getRealm(), user)
+              .collect(
+                  Collectors.toMap(
+                      FederatedIdentityModel::getIdentityProvider,
+                      FederatedIdentityModel::getUserName));
     }
 
-    private void logFoundIdps(String idpQualifier, String domainQualifier, List<IdentityProviderModel> homeIdps, String attribute, String username) {
-        String homeIdpsString = homeIdps.stream()
-                .map(IdentityProviderModel::getAlias)
-                .collect(Collectors.joining(","));
-        LOG.tracef("Found %s IdPs [%s] with %s attribute '%s' for user '%s'",
-                idpQualifier, homeIdpsString, domainQualifier, attribute, username);
+    List<IdentityProviderModel> candidateIdps =
+        identityProviders.candidatesForHomeIdp(context, user);
+    if (candidateIdps == null) {
+      candidateIdps = emptyList();
+    }
+    List<IdentityProviderModel> idpsWithMatchingDomain =
+        identityProviders.withMatchingAttribute(context, candidateIdps, attribute);
+    if (idpsWithMatchingDomain == null) {
+      idpsWithMatchingDomain = emptyList();
     }
 
-    private List<IdentityProviderModel> getLinkedIdpsFrom(List<IdentityProviderModel> enabledIdpsWithMatchingDomain, Map<String, String> linkedIdps) {
-        return enabledIdpsWithMatchingDomain.stream()
-                .filter(it -> linkedIdps.containsKey(it.getAlias()))
-                .collect(Collectors.toList());
+    // Prefer linked IdP with matching domain first
+    List<IdentityProviderModel> homeIdps = getLinkedIdpsFrom(idpsWithMatchingDomain, linkedIdps);
+
+    if (homeIdps.isEmpty()) {
+      if (!linkedIdps.isEmpty()) {
+        // Prefer linked and enabled IdPs without matching domain in favor of not linked IdPs with
+        // matching domain
+        homeIdps = getLinkedIdpsFrom(candidateIdps, linkedIdps);
+      }
+      if (homeIdps.isEmpty()) {
+        // Fallback to not linked IdPs with matching domain (general case if user logs in for the
+        // first time)
+        homeIdps = idpsWithMatchingDomain;
+        logFoundIdps("non-linked", "matching", homeIdps, attribute, username);
+      } else {
+        logFoundIdps("non-linked", "non-matching", homeIdps, attribute, username);
+      }
+    } else {
+      logFoundIdps("linked", "matching", homeIdps, attribute, username);
     }
 
-    @Override
-    public void close() {
-    }
+    return homeIdps;
+  }
+
+  private void logFoundIdps(
+      String idpQualifier,
+      String domainQualifier,
+      List<IdentityProviderModel> homeIdps,
+      String attribute,
+      String username) {
+    String homeIdpsString =
+        homeIdps.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(","));
+    LOG.tracef(
+        "Found %s IdPs [%s] with %s attribute '%s' for user '%s'",
+        idpQualifier, homeIdpsString, domainQualifier, attribute, username);
+  }
+
+  private List<IdentityProviderModel> getLinkedIdpsFrom(
+      List<IdentityProviderModel> enabledIdpsWithMatchingDomain, Map<String, String> linkedIdps) {
+    return enabledIdpsWithMatchingDomain.stream()
+        .filter(it -> linkedIdps.containsKey(it.getAlias()))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void close() {}
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/UserAttributeHomeIdpDiscovererConfig.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/UserAttributeHomeIdpDiscovererConfig.java
@@ -1,62 +1,64 @@
 package io.phasetwo.service.auth.idp.discovery.extattribute;
 
+import static org.keycloak.provider.ProviderConfigProperty.BOOLEAN_TYPE;
+import static org.keycloak.provider.ProviderConfigProperty.STRING_TYPE;
+
+import java.util.List;
+import java.util.Optional;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 
-import java.util.List;
-import java.util.Optional;
-
-import static org.keycloak.provider.ProviderConfigProperty.BOOLEAN_TYPE;
-import static org.keycloak.provider.ProviderConfigProperty.STRING_TYPE;
-
 final class UserAttributeHomeIdpDiscovererConfig {
 
-    private static final String FORWARD_TO_LINKED_IDP = "forwardToLinkedIdp";
-    private static final String USER_ATTRIBUTE = "userAttribute";
+  private static final String FORWARD_TO_LINKED_IDP = "forwardToLinkedIdp";
+  private static final String USER_ATTRIBUTE = "userAttribute";
 
-    private static final ProviderConfigProperty FORWARD_TO_LINKED_IDP_PROPERTY = new ProviderConfigProperty(
-        FORWARD_TO_LINKED_IDP,
-        "Forward to linked IdP",
-        "Whether to forward existing user to a linked identity provider or not.",
-        BOOLEAN_TYPE,
-        false,
-        false);
+  private static final ProviderConfigProperty FORWARD_TO_LINKED_IDP_PROPERTY =
+      new ProviderConfigProperty(
+          FORWARD_TO_LINKED_IDP,
+          "Forward to linked IdP",
+          "Whether to forward existing user to a linked identity provider or not.",
+          BOOLEAN_TYPE,
+          false,
+          false);
 
-    private static final ProviderConfigProperty USER_ATTRIBUTE_PROPERTY = new ProviderConfigProperty(
-        USER_ATTRIBUTE,
-        "User attribute",
-        "The user attribute used to match the identity provider.",
-        STRING_TYPE,
-        "id",
-        false);
+  private static final ProviderConfigProperty USER_ATTRIBUTE_PROPERTY =
+      new ProviderConfigProperty(
+          USER_ATTRIBUTE,
+          "User attribute",
+          "The user attribute used to match the identity provider.",
+          STRING_TYPE,
+          "id",
+          false);
 
+  static final List<ProviderConfigProperty> CONFIG_PROPERTIES =
+      ProviderConfigurationBuilder.create()
+          .property(USER_ATTRIBUTE_PROPERTY)
+          .property(FORWARD_TO_LINKED_IDP_PROPERTY)
+          .build();
+  private final AuthenticatorConfigModel authenticatorConfigModel;
 
-    static final List<ProviderConfigProperty> CONFIG_PROPERTIES = ProviderConfigurationBuilder.create()
-        .property(USER_ATTRIBUTE_PROPERTY)
-        .property(FORWARD_TO_LINKED_IDP_PROPERTY)
-        .build();
-    private final AuthenticatorConfigModel authenticatorConfigModel;
+  public UserAttributeHomeIdpDiscovererConfig(AuthenticatorConfigModel authenticatorConfigModel) {
+    this.authenticatorConfigModel = authenticatorConfigModel;
+  }
 
-    public UserAttributeHomeIdpDiscovererConfig(AuthenticatorConfigModel authenticatorConfigModel) {
-        this.authenticatorConfigModel = authenticatorConfigModel;
-    }
+  boolean forwardToLinkedIdp() {
+    return Optional.ofNullable(authenticatorConfigModel)
+        .map(
+            it -> Boolean.parseBoolean(it.getConfig().getOrDefault(FORWARD_TO_LINKED_IDP, "false")))
+        .orElse(false);
+  }
 
-    boolean forwardToLinkedIdp() {
-        return Optional.ofNullable(authenticatorConfigModel)
-            .map(it -> Boolean.parseBoolean(it.getConfig().getOrDefault(FORWARD_TO_LINKED_IDP, "false")))
-            .orElse(false);
-    }
+  String userAttribute() {
+    return Optional.ofNullable(authenticatorConfigModel)
+        .map(it -> it.getConfig().getOrDefault(USER_ATTRIBUTE, "email").trim())
+        .orElse("email");
+  }
 
-    String userAttribute() {
-        return Optional.ofNullable(authenticatorConfigModel)
-            .map(it -> it.getConfig().getOrDefault(USER_ATTRIBUTE, "email").trim())
-            .orElse("email");
-    }
-
-    String getAlias() {
-        return Optional.ofNullable(authenticatorConfigModel)
-            .map(AuthenticatorConfigModel::getAlias)
-            .orElse("<unconfigured>");
-    }
+  String getAlias() {
+    return Optional.ofNullable(authenticatorConfigModel)
+        .map(AuthenticatorConfigModel::getAlias)
+        .orElse("<unconfigured>");
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/UserAttributeHomeIdpDiscovererFactory.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/UserAttributeHomeIdpDiscovererFactory.java
@@ -5,45 +5,40 @@ import io.phasetwo.service.auth.idp.OperationalInfo;
 import io.phasetwo.service.auth.idp.Users;
 import io.phasetwo.service.auth.idp.discovery.spi.HomeIdpDiscoverer;
 import io.phasetwo.service.auth.idp.discovery.spi.HomeIdpDiscovererFactory;
+import java.util.Map;
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ServerInfoAwareProviderFactory;
 
-import java.util.Map;
-
 @AutoService(HomeIdpDiscovererFactory.class)
-public final class UserAttributeHomeIdpDiscovererFactory implements HomeIdpDiscovererFactory, ServerInfoAwareProviderFactory {
+public final class UserAttributeHomeIdpDiscovererFactory
+    implements HomeIdpDiscovererFactory, ServerInfoAwareProviderFactory {
 
-    static final String PROVIDER_ID = "ext-user-attribute";
+  static final String PROVIDER_ID = "ext-user-attribute";
 
-    @Override
-    public HomeIdpDiscoverer create(KeycloakSession keycloakSession) {
-        return new UserAttributeHomeIdpDiscoverer(new Users(keycloakSession), new DefaultIdentityProviders());
-    }
+  @Override
+  public HomeIdpDiscoverer create(KeycloakSession keycloakSession) {
+    return new UserAttributeHomeIdpDiscoverer(
+        new Users(keycloakSession), new DefaultIdentityProviders());
+  }
 
-    @Override
-    public void init(Config.Scope scope) {
+  @Override
+  public void init(Config.Scope scope) {}
 
-    }
+  @Override
+  public void postInit(KeycloakSessionFactory keycloakSessionFactory) {}
 
-    @Override
-    public void postInit(KeycloakSessionFactory keycloakSessionFactory) {
+  @Override
+  public void close() {}
 
-    }
+  @Override
+  public String getId() {
+    return PROVIDER_ID;
+  }
 
-    @Override
-    public void close() {
-
-    }
-
-    @Override
-    public String getId() {
-        return PROVIDER_ID;
-    }
-
-    @Override
-    public Map<String, String> getOperationalInfo() {
-        return OperationalInfo.get();
-    }
+  @Override
+  public Map<String, String> getOperationalInfo() {
+    return OperationalInfo.get();
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/UserAttributeHomeIdpDiscoveryAuthenticatorFactory.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/UserAttributeHomeIdpDiscoveryAuthenticatorFactory.java
@@ -5,31 +5,31 @@ import io.phasetwo.service.auth.idp.AbstractHomeIdpDiscoveryAuthenticatorFactory
 import org.keycloak.authentication.AuthenticatorFactory;
 
 @AutoService(AuthenticatorFactory.class)
-public final class UserAttributeHomeIdpDiscoveryAuthenticatorFactory extends AbstractHomeIdpDiscoveryAuthenticatorFactory implements AuthenticatorFactory {
-    private static final String PROVIDER_ID = "ext-user-attribute";
+public final class UserAttributeHomeIdpDiscoveryAuthenticatorFactory
+    extends AbstractHomeIdpDiscoveryAuthenticatorFactory implements AuthenticatorFactory {
+  private static final String PROVIDER_ID = "ext-user-attribute";
 
-    public UserAttributeHomeIdpDiscoveryAuthenticatorFactory() {
-        super(new UserAttributeHomeIdpDiscoveryAuthenticatorFactoryDiscovererConfig());
-    }
+  public UserAttributeHomeIdpDiscoveryAuthenticatorFactory() {
+    super(new UserAttributeHomeIdpDiscoveryAuthenticatorFactoryDiscovererConfig());
+  }
 
-    @Override
-    public String getDisplayType() {
-        return "Home IdP Discovery - Organization via user attribute";
-    }
+  @Override
+  public String getDisplayType() {
+    return "Home IdP Discovery - Organization via user attribute";
+  }
 
-    @Override
-    public String getReferenceCategory() {
-        return null;
-    }
+  @Override
+  public String getReferenceCategory() {
+    return null;
+  }
 
-    @Override
-    public String getHelpText() {
-        return "Redirects users to their organization's identity provider which will be discovered based on a user attribute";
-    }
+  @Override
+  public String getHelpText() {
+    return "Redirects users to their organization's identity provider which will be discovered based on a user attribute";
+  }
 
-    @Override
-    public String getId() {
-        return PROVIDER_ID;
-    }
-
+  @Override
+  public String getId() {
+    return PROVIDER_ID;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/UserAttributeHomeIdpDiscoveryAuthenticatorFactoryDiscovererConfig.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extattribute/UserAttributeHomeIdpDiscoveryAuthenticatorFactoryDiscovererConfig.java
@@ -1,18 +1,18 @@
 package io.phasetwo.service.auth.idp.discovery.extattribute;
 
 import io.phasetwo.service.auth.idp.AbstractHomeIdpDiscoveryAuthenticatorFactory;
+import java.util.List;
 import org.keycloak.provider.ProviderConfigProperty;
 
-import java.util.List;
+class UserAttributeHomeIdpDiscoveryAuthenticatorFactoryDiscovererConfig
+    implements AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig {
+  @Override
+  public List<ProviderConfigProperty> getProperties() {
+    return UserAttributeHomeIdpDiscovererConfig.CONFIG_PROPERTIES;
+  }
 
-class UserAttributeHomeIdpDiscoveryAuthenticatorFactoryDiscovererConfig implements AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig {
-    @Override
-    public List<ProviderConfigProperty> getProperties() {
-        return UserAttributeHomeIdpDiscovererConfig.CONFIG_PROPERTIES;
-    }
-
-    @Override
-    public String getProviderId() {
-        return UserAttributeHomeIdpDiscovererFactory.PROVIDER_ID;
-    }
+  @Override
+  public String getProviderId() {
+    return UserAttributeHomeIdpDiscovererFactory.PROVIDER_ID;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/DefaultIdentityProviders.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/DefaultIdentityProviders.java
@@ -1,26 +1,33 @@
 package io.phasetwo.service.auth.idp.discovery.extemail;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.IdentityProviderModel;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 final class DefaultIdentityProviders implements IdentityProviders {
 
-    private static final Logger LOG = Logger.getLogger(DefaultIdentityProviders.class);
+  private static final Logger LOG = Logger.getLogger(DefaultIdentityProviders.class);
 
-    @Override
-    public List<IdentityProviderModel> withMatchingDomain(AuthenticationFlowContext context, List<IdentityProviderModel> candidates, Domain domain) {
-        EmailHomeIdpDiscovererConfig config = new EmailHomeIdpDiscovererConfig(context.getAuthenticatorConfig());
-        String userAttributeName = config.userAttribute();
-        List<IdentityProviderModel> idpsWithMatchingDomain = candidates.stream()
-            .filter(it -> new IdentityProviderModelConfig(it).supportsDomain(userAttributeName, domain))
+  @Override
+  public List<IdentityProviderModel> withMatchingDomain(
+      AuthenticationFlowContext context, List<IdentityProviderModel> candidates, Domain domain) {
+    EmailHomeIdpDiscovererConfig config =
+        new EmailHomeIdpDiscovererConfig(context.getAuthenticatorConfig());
+    String userAttributeName = config.userAttribute();
+    List<IdentityProviderModel> idpsWithMatchingDomain =
+        candidates.stream()
+            .filter(
+                it -> new IdentityProviderModelConfig(it).supportsDomain(userAttributeName, domain))
             .collect(Collectors.toList());
-        LOG.tracef("IdPs with matching domain '%s' for attribute '%s': %s", domain, userAttributeName,
-            idpsWithMatchingDomain.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(",")));
-        return idpsWithMatchingDomain;
-    }
-
+    LOG.tracef(
+        "IdPs with matching domain '%s' for attribute '%s': %s",
+        domain,
+        userAttributeName,
+        idpsWithMatchingDomain.stream()
+            .map(IdentityProviderModel::getAlias)
+            .collect(Collectors.joining(",")));
+    return idpsWithMatchingDomain;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/Domain.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/Domain.java
@@ -1,42 +1,38 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp.discovery.extemail;
 
 import io.phasetwo.service.auth.idp.PublicAPI;
-
 import java.util.Objects;
 
 @PublicAPI(unstable = true)
 public final class Domain {
 
-    private final String value;
+  private final String value;
 
-    Domain(String value) {
-        Objects.requireNonNull(value);
-        this.value = value.toLowerCase();
-    }
+  Domain(String value) {
+    Objects.requireNonNull(value);
+    this.value = value.toLowerCase();
+  }
 
-    boolean isSubDomainOf(Domain domain) {
-        return this.value.endsWith("." + domain.value);
-    }
+  boolean isSubDomainOf(Domain domain) {
+    return this.value.endsWith("." + domain.value);
+  }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null)
-            return false;
-        if (!(obj instanceof Domain))
-            return false;
-        if (this == obj)
-            return true;
-        return this.value.equalsIgnoreCase(((Domain) obj).value);
-    }
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) return false;
+    if (!(obj instanceof Domain)) return false;
+    if (this == obj) return true;
+    return this.value.equalsIgnoreCase(((Domain) obj).value);
+  }
 
-    @Override
-    public int hashCode() {
-        return this.value.hashCode();
-    }
+  @Override
+  public int hashCode() {
+    return this.value.hashCode();
+  }
 
-    @Override
-    public String toString() {
-        return this.value;
-    }
+  @Override
+  public String toString() {
+    return this.value;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/DomainExtractor.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/DomainExtractor.java
@@ -1,42 +1,41 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp.discovery.extemail;
 
+import java.util.Optional;
 import org.jboss.logging.Logger;
 import org.keycloak.models.UserModel;
 
-import java.util.Optional;
-
 final class DomainExtractor {
 
-    private static final Logger LOG = Logger.getLogger(DomainExtractor.class);
+  private static final Logger LOG = Logger.getLogger(DomainExtractor.class);
 
-    private final EmailHomeIdpDiscovererConfig config;
+  private final EmailHomeIdpDiscovererConfig config;
 
-    DomainExtractor(EmailHomeIdpDiscovererConfig config) {
-        this.config = config;
+  DomainExtractor(EmailHomeIdpDiscovererConfig config) {
+    this.config = config;
+  }
+
+  Optional<Domain> extractFrom(UserModel user) {
+    String userAttribute = user.getFirstAttribute(config.userAttribute());
+    if (userAttribute == null) {
+      LOG.warnf(
+          "Could not find user attribute '%s' for user '%s'", config.userAttribute(), user.getId());
+      return Optional.empty();
     }
+    return extractFrom(userAttribute);
+  }
 
-    Optional<Domain> extractFrom(UserModel user) {
-        String userAttribute = user.getFirstAttribute(config.userAttribute());
-        if (userAttribute == null) {
-            LOG.warnf("Could not find user attribute '%s' for user '%s'", config.userAttribute(), user.getId());
-            return Optional.empty();
+  Optional<Domain> extractFrom(String usernameOrEmail) {
+    Domain domain = null;
+    if (usernameOrEmail != null) {
+      int atIndex = usernameOrEmail.trim().lastIndexOf("@");
+      if (atIndex >= 0) {
+        String strDomain = usernameOrEmail.trim().substring(atIndex + 1);
+        if (strDomain.length() > 0) {
+          domain = new Domain(strDomain);
         }
-        return extractFrom(userAttribute);
+      }
     }
-
-    Optional<Domain> extractFrom(String usernameOrEmail) {
-        Domain domain = null;
-        if (usernameOrEmail != null) {
-            int atIndex = usernameOrEmail.trim().lastIndexOf("@");
-            if (atIndex >= 0) {
-                String strDomain = usernameOrEmail.trim().substring(atIndex + 1);
-                if (strDomain.length() > 0) {
-                    domain = new Domain(strDomain);
-                }
-            }
-        }
-        return Optional.ofNullable(domain);
-    }
-
+    return Optional.ofNullable(domain);
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/EmailHomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/EmailHomeIdpDiscoverer.java
@@ -1,237 +1,272 @@
 package io.phasetwo.service.auth.idp.discovery.extemail;
 
+import static io.phasetwo.service.Orgs.ORG_CONFIG_VALIDATE_IDP_KEY;
+import static io.phasetwo.service.Orgs.ORG_DOMAIN_CONFIG_KEY;
+import static io.phasetwo.service.Orgs.ORG_VALIDATION_PENDING_CONFIG_KEY;
+
 import com.google.common.base.Strings;
 import io.phasetwo.service.auth.idp.PublicAPI;
 import io.phasetwo.service.auth.idp.Users;
 import io.phasetwo.service.auth.idp.discovery.spi.HomeIdpDiscoverer;
 import io.phasetwo.service.model.OrganizationModel;
 import io.phasetwo.service.model.OrganizationProvider;
+import java.util.*;
+import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.*;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static io.phasetwo.service.Orgs.ORG_CONFIG_VALIDATE_IDP_KEY;
-import static io.phasetwo.service.Orgs.ORG_DOMAIN_CONFIG_KEY;
-import static io.phasetwo.service.Orgs.ORG_VALIDATION_PENDING_CONFIG_KEY;
-
 @PublicAPI(unstable = true)
 public final class EmailHomeIdpDiscoverer implements HomeIdpDiscoverer {
 
-    private static final Logger LOG = Logger.getLogger(EmailHomeIdpDiscoverer.class);
-    private static final String EMAIL_ATTRIBUTE = "email";
-    private final Users users;
-    private final IdentityProviders identityProviders;
+  private static final Logger LOG = Logger.getLogger(EmailHomeIdpDiscoverer.class);
+  private static final String EMAIL_ATTRIBUTE = "email";
+  private final Users users;
+  private final IdentityProviders identityProviders;
 
-    @PublicAPI(unstable = true)
-    public EmailHomeIdpDiscoverer(Users users, IdentityProviders identityProviders) {
-        this.users = users;
-        this.identityProviders = identityProviders;
+  @PublicAPI(unstable = true)
+  public EmailHomeIdpDiscoverer(Users users, IdentityProviders identityProviders) {
+    this.users = users;
+    this.identityProviders = identityProviders;
+  }
+
+  @Override
+  public List<IdentityProviderModel> discoverForUser(
+      AuthenticationFlowContext context, String username) {
+
+    String realmName = context.getRealm().getName();
+    EmailHomeIdpDiscovererConfig config =
+        new EmailHomeIdpDiscovererConfig(context.getAuthenticatorConfig());
+    LOG.tracef(
+        "Trying to discover home IdP for username '%s' in realm '%s' with authenticator config '%s'",
+        username, realmName, config == null ? "<unconfigured>" : config.getAlias());
+
+    DomainExtractor domainExtractor = new DomainExtractor(config);
+    LOG.tracef(
+        "Trying to discover home IdP for username '%s' in realm '%s' with authenticator config '%s'",
+        username, realmName, config.getAlias());
+
+    List<IdentityProviderModel> homeIdps = new ArrayList<>();
+
+    final Optional<Domain> emailDomain;
+    UserModel user = users.lookupBy(username);
+    if (user == null) {
+      LOG.tracef(
+          "No user found in AuthenticationFlowContext. Extracting domain from provided username '%s'.",
+          username);
+      emailDomain = domainExtractor.extractFrom(username);
+    } else {
+      LOG.tracef(
+          "User found in AuthenticationFlowContext. Extracting domain from stored user '%s'.",
+          user.getId());
+      if (EMAIL_ATTRIBUTE.equalsIgnoreCase(config.userAttribute())
+          && !user.isEmailVerified()
+          && config.requireVerifiedEmail()) {
+        LOG.warnf(
+            "Email address of user '%s' is not verified and forwarding not enabled", user.getId());
+        emailDomain = Optional.empty();
+      } else {
+        emailDomain = domainExtractor.extractFrom(user);
+      }
     }
 
-    @Override
-    public List<IdentityProviderModel> discoverForUser(AuthenticationFlowContext context, String username) {
-
-        String realmName = context.getRealm().getName();
-        EmailHomeIdpDiscovererConfig config = new EmailHomeIdpDiscovererConfig(context.getAuthenticatorConfig());
-        LOG.tracef("Trying to discover home IdP for username '%s' in realm '%s' with authenticator config '%s'",
-                username, realmName, config == null ? "<unconfigured>" : config.getAlias());
-
-        DomainExtractor domainExtractor = new DomainExtractor(config);
-        LOG.tracef("Trying to discover home IdP for username '%s' in realm '%s' with authenticator config '%s'",
-                username, realmName, config.getAlias());
-
-        List<IdentityProviderModel> homeIdps = new ArrayList<>();
-
-        final Optional<Domain> emailDomain;
-        UserModel user = users.lookupBy(username);
-        if (user == null) {
-            LOG.tracef("No user found in AuthenticationFlowContext. Extracting domain from provided username '%s'.",
-                    username);
-            emailDomain = domainExtractor.extractFrom(username);
-        } else {
-            LOG.tracef("User found in AuthenticationFlowContext. Extracting domain from stored user '%s'.",
-                    user.getId());
-            if (EMAIL_ATTRIBUTE.equalsIgnoreCase(config.userAttribute())
-                    && !user.isEmailVerified()
-                    && config.requireVerifiedEmail()) {
-                LOG.warnf("Email address of user '%s' is not verified and forwarding not enabled", user.getId());
-                emailDomain = Optional.empty();
-            } else {
-                emailDomain = domainExtractor.extractFrom(user);
-            }
-        }
-
-        if (emailDomain.isPresent()) {
-            Domain domain = emailDomain.get();
-            homeIdps = discoverHomeIdps(context, domain, user, username);
-            if (homeIdps.isEmpty()) {
-                LOG.debugf("Could not find home IdP for domain '%s' and user '%s' in realm '%s'",
-                        domain, username, realmName);
-            } else {
-                String homeIdpsString = homeIdps.stream()
-                        .map(IdentityProviderModel::getAlias)
-                        .collect(Collectors.joining(","));
-                LOG.infof("Found IdPs [%s] with domain '%s' for user '%s'", homeIdpsString, domain, username);
-            }
-        } else {
-            LOG.warnf("Could not extract domain from email address '%s'", username);
-        }
-
-        return homeIdps;
+    if (emailDomain.isPresent()) {
+      Domain domain = emailDomain.get();
+      homeIdps = discoverHomeIdps(context, domain, user, username);
+      if (homeIdps.isEmpty()) {
+        LOG.debugf(
+            "Could not find home IdP for domain '%s' and user '%s' in realm '%s'",
+            domain, username, realmName);
+      } else {
+        String homeIdpsString =
+            homeIdps.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(","));
+        LOG.infof(
+            "Found IdPs [%s] with domain '%s' for user '%s'", homeIdpsString, domain, username);
+      }
+    } else {
+      LOG.warnf("Could not extract domain from email address '%s'", username);
     }
 
-    /**
-     * Get a list of idps given an email domain, user and username.
-     * 1. If the user is set in the context, initially look up the set of federated identities that match the user.
-     * 2. Look up all enabled idps for the realm. This seems unneccessary and a performance risk.
-     * 3. Get a stream of organizations with a matching email domain. Map those to idps.
-     * 3a. If multi-idps is turned on, get a subset of that list with domain matches in the config.
-     * 4. Get a subset of the list that match the user's federated identities. Return that if it's non-empty.
-     * 5. If empty, but user has linked idps, prefer linked and enabled IdPs without matching domain in favor of not linked IdPs with matching domain
-     * 6. If empty, but user doesn't have linked idps, fallback to not linked IdPs with matching domain (general case if user logs in for the first time)
-     * @param domain Email domain
-     * @param user User if set in the context
-     * @param username Username or email
-     * @returns A list of Identity Providers
-     */
-    private List<IdentityProviderModel> discoverHomeIdps(AuthenticationFlowContext context, Domain domain, UserModel user, String username) {
-        final Map<String, String> linkedIdps;
+    return homeIdps;
+  }
 
-        EmailHomeIdpDiscovererConfig config = new EmailHomeIdpDiscovererConfig(context.getAuthenticatorConfig());
-        if (user == null || !config.forwardToLinkedIdp()) {
-            linkedIdps = Collections.emptyMap();
-            LOG.tracef(
-                    "User '%s' is not stored locally or forwarding to linked IdP is disabled. Skipping discovery of linked IdPs.",
-                    username);
-        } else {
-            LOG.tracef(
-                    "Found local user '%s' and forwarding to linked IdP is enabled. Discovering linked IdPs.",
-                    username);
-            linkedIdps = context
-                    .getSession()
-                    .users()
-                    .getFederatedIdentitiesStream(context.getRealm(), user)
-                    .collect(
-                            Collectors.toMap(FederatedIdentityModel::getIdentityProvider, FederatedIdentityModel::getUserName));
-        }
+  /**
+   * Get a list of idps given an email domain, user and username. 1. If the user is set in the
+   * context, initially look up the set of federated identities that match the user. 2. Look up all
+   * enabled idps for the realm. This seems unneccessary and a performance risk. 3. Get a stream of
+   * organizations with a matching email domain. Map those to idps. 3a. If multi-idps is turned on,
+   * get a subset of that list with domain matches in the config. 4. Get a subset of the list that
+   * match the user's federated identities. Return that if it's non-empty. 5. If empty, but user has
+   * linked idps, prefer linked and enabled IdPs without matching domain in favor of not linked IdPs
+   * with matching domain 6. If empty, but user doesn't have linked idps, fallback to not linked
+   * IdPs with matching domain (general case if user logs in for the first time)
+   *
+   * @param domain Email domain
+   * @param user User if set in the context
+   * @param username Username or email
+   * @returns A list of Identity Providers
+   */
+  private List<IdentityProviderModel> discoverHomeIdps(
+      AuthenticationFlowContext context, Domain domain, UserModel user, String username) {
+    final Map<String, String> linkedIdps;
 
-        List<IdentityProviderModel> enabledIdps = determineEnabledIdps(context);
-        // Original; lookup mechanism from https://github.com/sventorben/keycloak-home-idp-discovery
-        /*
-        List<IdentityProviderModel> enabledIdpsWithMatchingDomain = filterIdpsWithMatchingDomainFrom(enabledIdps,
-            domain,
-            config);
-        */
-        // Overidden lookup mechanism to lookup via organization domain
-        OrganizationProvider orgs = context.getSession().getProvider(OrganizationProvider.class);
-        boolean validateIdpEnabled = context.getRealm().getAttribute(ORG_CONFIG_VALIDATE_IDP_KEY, false);
-        List<IdentityProviderModel> enabledIdpsWithMatchingDomain =
-                orgs.getOrganizationsStreamForDomain(
-                                context.getRealm(), domain.toString(), config.requireVerifiedDomain())
-                        .flatMap(OrganizationModel::getIdentityProvidersStream)
-                        .filter(IdentityProviderModel::isEnabled)
-                        .filter(
-                                idp ->
-                                        !validateIdpEnabled
-                                                || !isIdpValidationPending(idp))
-                        .collect(Collectors.toList());
-
-        // If multi-idps is turned on, get a subset of that list with domain matches in the config.
-        if (io.phasetwo.service.util.IdentityProviders.isMultipleIdpsConfigEnabled(context.getRealm())) {
-            List<IdentityProviderModel> domainMatchingIdps =
-                    enabledIdpsWithMatchingDomain
-                            .stream()
-                            .filter(idp -> {
-                                String domains = idp.getConfig().get(ORG_DOMAIN_CONFIG_KEY);
-                                if (Strings.isNullOrEmpty(domains)) return false;
-                                return io.phasetwo.service.util.IdentityProviders.strListContains(domains, domain.toString());
-                            })
-                            .distinct()
-                            .collect(Collectors.toList());
-            // If there are _any_ matches, use that list. If there are none, use the original list.
-            if (!domainMatchingIdps.isEmpty()) {
-                enabledIdpsWithMatchingDomain = domainMatchingIdps;
-            }
-        }
-
-        // Prefer linked IdP with matching domain first
-        List<IdentityProviderModel> homeIdps = getLinkedIdpsFrom(enabledIdpsWithMatchingDomain, linkedIdps);
-
-        if (homeIdps.isEmpty()) {
-            if (!linkedIdps.isEmpty()) {
-                // Prefer linked and enabled IdPs without matching domain in favor of not linked IdPs with matching domain
-                homeIdps = getLinkedIdpsFrom(enabledIdps, linkedIdps);
-            }
-            if (homeIdps.isEmpty()) {
-                // Fallback to not linked IdPs with matching domain (general case if user logs in for the first time)
-                homeIdps = enabledIdpsWithMatchingDomain;
-                logFoundIdps("non-linked", "matching", homeIdps, domain, username);
-            } else {
-                logFoundIdps("non-linked", "non-matching", homeIdps, domain, username);
-            }
-        } else {
-            logFoundIdps("linked", "matching", homeIdps, domain, username);
-        }
-
-        return homeIdps;
+    EmailHomeIdpDiscovererConfig config =
+        new EmailHomeIdpDiscovererConfig(context.getAuthenticatorConfig());
+    if (user == null || !config.forwardToLinkedIdp()) {
+      linkedIdps = Collections.emptyMap();
+      LOG.tracef(
+          "User '%s' is not stored locally or forwarding to linked IdP is disabled. Skipping discovery of linked IdPs.",
+          username);
+    } else {
+      LOG.tracef(
+          "Found local user '%s' and forwarding to linked IdP is enabled. Discovering linked IdPs.",
+          username);
+      linkedIdps =
+          context
+              .getSession()
+              .users()
+              .getFederatedIdentitiesStream(context.getRealm(), user)
+              .collect(
+                  Collectors.toMap(
+                      FederatedIdentityModel::getIdentityProvider,
+                      FederatedIdentityModel::getUserName));
     }
 
-    private void logFoundIdps(String idpQualifier, String domainQualifier, List<IdentityProviderModel> homeIdps, Domain domain, String username) {
-        String homeIdpsString = homeIdps.stream()
-                .map(IdentityProviderModel::getAlias)
-                .collect(Collectors.joining(","));
-        LOG.tracef("Found %s IdPs [%s] with %s domain '%s' for user '%s'",
-                idpQualifier, homeIdpsString, domainQualifier, domain, username);
+    List<IdentityProviderModel> enabledIdps = determineEnabledIdps(context);
+    // Original; lookup mechanism from https://github.com/sventorben/keycloak-home-idp-discovery
+    /*
+    List<IdentityProviderModel> enabledIdpsWithMatchingDomain = filterIdpsWithMatchingDomainFrom(enabledIdps,
+        domain,
+        config);
+    */
+    // Overidden lookup mechanism to lookup via organization domain
+    OrganizationProvider orgs = context.getSession().getProvider(OrganizationProvider.class);
+    boolean validateIdpEnabled =
+        context.getRealm().getAttribute(ORG_CONFIG_VALIDATE_IDP_KEY, false);
+    List<IdentityProviderModel> enabledIdpsWithMatchingDomain =
+        orgs.getOrganizationsStreamForDomain(
+                context.getRealm(), domain.toString(), config.requireVerifiedDomain())
+            .flatMap(OrganizationModel::getIdentityProvidersStream)
+            .filter(IdentityProviderModel::isEnabled)
+            .filter(idp -> !validateIdpEnabled || !isIdpValidationPending(idp))
+            .collect(Collectors.toList());
+
+    // If multi-idps is turned on, get a subset of that list with domain matches in the config.
+    if (io.phasetwo.service.util.IdentityProviders.isMultipleIdpsConfigEnabled(
+        context.getRealm())) {
+      List<IdentityProviderModel> domainMatchingIdps =
+          enabledIdpsWithMatchingDomain.stream()
+              .filter(
+                  idp -> {
+                    String domains = idp.getConfig().get(ORG_DOMAIN_CONFIG_KEY);
+                    if (Strings.isNullOrEmpty(domains)) return false;
+                    return io.phasetwo.service.util.IdentityProviders.strListContains(
+                        domains, domain.toString());
+                  })
+              .distinct()
+              .collect(Collectors.toList());
+      // If there are _any_ matches, use that list. If there are none, use the original list.
+      if (!domainMatchingIdps.isEmpty()) {
+        enabledIdpsWithMatchingDomain = domainMatchingIdps;
+      }
     }
 
-    /**
-     * Given a list of idps and a map of idp alias to federated username, return a subset of the list that are contained in the map keys.
-     * @param enabledIdpsWithMatchingDomain A list of identity providers
-     * @param linkedIdps A map of idp alias to federated username
-     * @returns A subset of the list that are contained in the map keys
-     */
-    private List<IdentityProviderModel> getLinkedIdpsFrom(List<IdentityProviderModel> enabledIdpsWithMatchingDomain, Map<String, String> linkedIdps) {
-        return enabledIdpsWithMatchingDomain.stream()
-                .filter(it -> linkedIdps.containsKey(it.getAlias()))
-                .collect(Collectors.toList());
+    // Prefer linked IdP with matching domain first
+    List<IdentityProviderModel> homeIdps =
+        getLinkedIdpsFrom(enabledIdpsWithMatchingDomain, linkedIdps);
+
+    if (homeIdps.isEmpty()) {
+      if (!linkedIdps.isEmpty()) {
+        // Prefer linked and enabled IdPs without matching domain in favor of not linked IdPs with
+        // matching domain
+        homeIdps = getLinkedIdpsFrom(enabledIdps, linkedIdps);
+      }
+      if (homeIdps.isEmpty()) {
+        // Fallback to not linked IdPs with matching domain (general case if user logs in for the
+        // first time)
+        homeIdps = enabledIdpsWithMatchingDomain;
+        logFoundIdps("non-linked", "matching", homeIdps, domain, username);
+      } else {
+        logFoundIdps("non-linked", "non-matching", homeIdps, domain, username);
+      }
+    } else {
+      logFoundIdps("linked", "matching", homeIdps, domain, username);
     }
 
-    private boolean isIdpValidationPending(IdentityProviderModel idp) {
-        return Boolean.parseBoolean(
-                Optional.ofNullable(idp.getConfig())
-                        .map(cfg -> cfg.get(ORG_VALIDATION_PENDING_CONFIG_KEY))
-                        .orElse(null));
-    }
+    return homeIdps;
+  }
 
-//
-//    private List<IdentityProviderModel> filterIdpsWithMatchingDomainFrom(List<IdentityProviderModel> enabledIdps, Domain domain, HomeIdpDiscoveryConfig config) {
-//        String userAttributeName = config.userAttribute();
-//        List<IdentityProviderModel> idpsWithMatchingDomain = enabledIdps.stream()
-//                .filter(it -> new io.phasetwo.service.auth.idp.IdentityProviderModelConfig(it).supportsDomain(userAttributeName, domain))
-//                .collect(Collectors.toList());
-//        LOG.tracef("IdPs with matching domain '%s' for attribute '%s': %s", domain, userAttributeName,
-//                idpsWithMatchingDomain.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(",")));
-//        return idpsWithMatchingDomain;
-//    }
+  private void logFoundIdps(
+      String idpQualifier,
+      String domainQualifier,
+      List<IdentityProviderModel> homeIdps,
+      Domain domain,
+      String username) {
+    String homeIdpsString =
+        homeIdps.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(","));
+    LOG.tracef(
+        "Found %s IdPs [%s] with %s domain '%s' for user '%s'",
+        idpQualifier, homeIdpsString, domainQualifier, domain, username);
+  }
 
-    /**
-     * @returns A list of all enabled idps for a realm.
-     */
-    private List<IdentityProviderModel> determineEnabledIdps(AuthenticationFlowContext context) {
-        RealmModel realm = context.getRealm();
-        List<IdentityProviderModel> enabledIdps = context.getSession().identityProviders().getAllStream()
-                .filter(IdentityProviderModel::isEnabled)
-                .collect(Collectors.toList());
-        LOG.tracef("Enabled IdPs in realm '%s': %s",
-                realm.getName(),
-                enabledIdps.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(",")));
-        return enabledIdps;
-    }
+  /**
+   * Given a list of idps and a map of idp alias to federated username, return a subset of the list
+   * that are contained in the map keys.
+   *
+   * @param enabledIdpsWithMatchingDomain A list of identity providers
+   * @param linkedIdps A map of idp alias to federated username
+   * @returns A subset of the list that are contained in the map keys
+   */
+  private List<IdentityProviderModel> getLinkedIdpsFrom(
+      List<IdentityProviderModel> enabledIdpsWithMatchingDomain, Map<String, String> linkedIdps) {
+    return enabledIdpsWithMatchingDomain.stream()
+        .filter(it -> linkedIdps.containsKey(it.getAlias()))
+        .collect(Collectors.toList());
+  }
 
-    @Override
-    public void close() {
-    }
+  private boolean isIdpValidationPending(IdentityProviderModel idp) {
+    return Boolean.parseBoolean(
+        Optional.ofNullable(idp.getConfig())
+            .map(cfg -> cfg.get(ORG_VALIDATION_PENDING_CONFIG_KEY))
+            .orElse(null));
+  }
+
+  //
+  //    private List<IdentityProviderModel>
+  // filterIdpsWithMatchingDomainFrom(List<IdentityProviderModel> enabledIdps, Domain domain,
+  // HomeIdpDiscoveryConfig config) {
+  //        String userAttributeName = config.userAttribute();
+  //        List<IdentityProviderModel> idpsWithMatchingDomain = enabledIdps.stream()
+  //                .filter(it -> new
+  // io.phasetwo.service.auth.idp.IdentityProviderModelConfig(it).supportsDomain(userAttributeName,
+  // domain))
+  //                .collect(Collectors.toList());
+  //        LOG.tracef("IdPs with matching domain '%s' for attribute '%s': %s", domain,
+  // userAttributeName,
+  //
+  // idpsWithMatchingDomain.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(",")));
+  //        return idpsWithMatchingDomain;
+  //    }
+
+  /**
+   * @returns A list of all enabled idps for a realm.
+   */
+  private List<IdentityProviderModel> determineEnabledIdps(AuthenticationFlowContext context) {
+    RealmModel realm = context.getRealm();
+    List<IdentityProviderModel> enabledIdps =
+        context
+            .getSession()
+            .identityProviders()
+            .getAllStream()
+            .filter(IdentityProviderModel::isEnabled)
+            .collect(Collectors.toList());
+    LOG.tracef(
+        "Enabled IdPs in realm '%s': %s",
+        realm.getName(),
+        enabledIdps.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(",")));
+    return enabledIdps;
+  }
+
+  @Override
+  public void close() {}
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/EmailHomeIdpDiscovererConfig.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/EmailHomeIdpDiscovererConfig.java
@@ -1,102 +1,103 @@
-//package de.sventorben.keycloak.authentication.hidpd.discovery.email;
+// package de.sventorben.keycloak.authentication.hidpd.discovery.email;
 package io.phasetwo.service.auth.idp.discovery.extemail;
-
-import org.keycloak.models.AuthenticatorConfigModel;
-import org.keycloak.provider.ProviderConfigProperty;
-import org.keycloak.provider.ProviderConfigurationBuilder;
-
-import java.util.List;
-import java.util.Optional;
 
 import static org.keycloak.provider.ProviderConfigProperty.BOOLEAN_TYPE;
 import static org.keycloak.provider.ProviderConfigProperty.STRING_TYPE;
 
+import java.util.List;
+import java.util.Optional;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
 final class EmailHomeIdpDiscovererConfig {
 
-    private static final String FORWARD_TO_LINKED_IDP = "forwardToLinkedIdp";
-    private static final String USER_ATTRIBUTE = "userAttribute";
-    private static final String REQUIRE_VERIFIED_EMAIL = "requireVerifiedEmail";
-    private static final String REQUIRE_VERIFIED_DOMAIN = "requireVerifiedDomain";
+  private static final String FORWARD_TO_LINKED_IDP = "forwardToLinkedIdp";
+  private static final String USER_ATTRIBUTE = "userAttribute";
+  private static final String REQUIRE_VERIFIED_EMAIL = "requireVerifiedEmail";
+  private static final String REQUIRE_VERIFIED_DOMAIN = "requireVerifiedDomain";
 
-    private static final ProviderConfigProperty FORWARD_TO_LINKED_IDP_PROPERTY = new ProviderConfigProperty(
-        FORWARD_TO_LINKED_IDP,
-        "Forward to linked IdP",
-        "Whether to forward existing user to a linked identity provider or not.",
-        BOOLEAN_TYPE,
-        false,
-        false);
+  private static final ProviderConfigProperty FORWARD_TO_LINKED_IDP_PROPERTY =
+      new ProviderConfigProperty(
+          FORWARD_TO_LINKED_IDP,
+          "Forward to linked IdP",
+          "Whether to forward existing user to a linked identity provider or not.",
+          BOOLEAN_TYPE,
+          false,
+          false);
 
-    private static final ProviderConfigProperty USER_ATTRIBUTE_PROPERTY = new ProviderConfigProperty(
-        USER_ATTRIBUTE,
-        "User attribute",
-        "The user attribute used to lookup the email address of the user.",
-        STRING_TYPE,
-        "email",
-        false);
+  private static final ProviderConfigProperty USER_ATTRIBUTE_PROPERTY =
+      new ProviderConfigProperty(
+          USER_ATTRIBUTE,
+          "User attribute",
+          "The user attribute used to lookup the email address of the user.",
+          STRING_TYPE,
+          "email",
+          false);
 
-    private static final ProviderConfigProperty REQUIRE_VERIFIED_EMAIL_PROPERTY =
-            new ProviderConfigProperty(
-                    REQUIRE_VERIFIED_EMAIL,
-                    "Require a verified email",
-                    "Whether a verified email address for a user is required to forward to their identity provider.",
-                    BOOLEAN_TYPE,
-                    false,
-                    false);
+  private static final ProviderConfigProperty REQUIRE_VERIFIED_EMAIL_PROPERTY =
+      new ProviderConfigProperty(
+          REQUIRE_VERIFIED_EMAIL,
+          "Require a verified email",
+          "Whether a verified email address for a user is required to forward to their identity provider.",
+          BOOLEAN_TYPE,
+          false,
+          false);
 
-    private static final ProviderConfigProperty REQUIRE_VERIFIED_DOMAIN_PROPERTY =
-            new ProviderConfigProperty(
-                    REQUIRE_VERIFIED_DOMAIN,
-                    "Require a verified domain",
-                    "Whether a verified domain name for an organization is required to forward to their identity provider.",
-                    BOOLEAN_TYPE,
-                    false,
-                    false);
+  private static final ProviderConfigProperty REQUIRE_VERIFIED_DOMAIN_PROPERTY =
+      new ProviderConfigProperty(
+          REQUIRE_VERIFIED_DOMAIN,
+          "Require a verified domain",
+          "Whether a verified domain name for an organization is required to forward to their identity provider.",
+          BOOLEAN_TYPE,
+          false,
+          false);
 
+  static final List<ProviderConfigProperty> CONFIG_PROPERTIES =
+      ProviderConfigurationBuilder.create()
+          .property(USER_ATTRIBUTE_PROPERTY)
+          .property(FORWARD_TO_LINKED_IDP_PROPERTY)
+          .property(REQUIRE_VERIFIED_EMAIL_PROPERTY)
+          .property(REQUIRE_VERIFIED_DOMAIN_PROPERTY)
+          .build();
+  private final AuthenticatorConfigModel authenticatorConfigModel;
 
+  public EmailHomeIdpDiscovererConfig(AuthenticatorConfigModel authenticatorConfigModel) {
+    this.authenticatorConfigModel = authenticatorConfigModel;
+  }
 
-    static final List<ProviderConfigProperty> CONFIG_PROPERTIES = ProviderConfigurationBuilder.create()
-        .property(USER_ATTRIBUTE_PROPERTY)
-        .property(FORWARD_TO_LINKED_IDP_PROPERTY)
-        .property(REQUIRE_VERIFIED_EMAIL_PROPERTY)
-        .property(REQUIRE_VERIFIED_DOMAIN_PROPERTY)
-        .build();
-    private final AuthenticatorConfigModel authenticatorConfigModel;
+  boolean forwardToLinkedIdp() {
+    return Optional.ofNullable(authenticatorConfigModel)
+        .map(
+            it -> Boolean.parseBoolean(it.getConfig().getOrDefault(FORWARD_TO_LINKED_IDP, "false")))
+        .orElse(false);
+  }
 
-    public EmailHomeIdpDiscovererConfig(AuthenticatorConfigModel authenticatorConfigModel) {
-        this.authenticatorConfigModel = authenticatorConfigModel;
-    }
+  String userAttribute() {
+    return Optional.ofNullable(authenticatorConfigModel)
+        .map(it -> it.getConfig().getOrDefault(USER_ATTRIBUTE, "email").trim())
+        .orElse("email");
+  }
 
-    boolean forwardToLinkedIdp() {
-        return Optional.ofNullable(authenticatorConfigModel)
-            .map(it -> Boolean.parseBoolean(it.getConfig().getOrDefault(FORWARD_TO_LINKED_IDP, "false")))
-            .orElse(false);
-    }
+  boolean requireVerifiedEmail() {
+    return Optional.ofNullable(authenticatorConfigModel)
+        .map(
+            it ->
+                Boolean.parseBoolean(it.getConfig().getOrDefault(REQUIRE_VERIFIED_EMAIL, "false")))
+        .orElse(false);
+  }
 
-    String userAttribute() {
-        return Optional.ofNullable(authenticatorConfigModel)
-            .map(it -> it.getConfig().getOrDefault(USER_ATTRIBUTE, "email").trim())
-            .orElse("email");
-    }
+  boolean requireVerifiedDomain() {
+    return Optional.ofNullable(authenticatorConfigModel)
+        .map(
+            it ->
+                Boolean.parseBoolean(it.getConfig().getOrDefault(REQUIRE_VERIFIED_DOMAIN, "false")))
+        .orElse(false);
+  }
 
-    boolean requireVerifiedEmail() {
-        return Optional.ofNullable(authenticatorConfigModel)
-                .map(
-                        it ->
-                                Boolean.parseBoolean(it.getConfig().getOrDefault(REQUIRE_VERIFIED_EMAIL, "false")))
-                .orElse(false);
-    }
-
-    boolean requireVerifiedDomain() {
-        return Optional.ofNullable(authenticatorConfigModel)
-                .map(
-                        it ->
-                                Boolean.parseBoolean(it.getConfig().getOrDefault(REQUIRE_VERIFIED_DOMAIN, "false")))
-                .orElse(false);
-    }
-
-    String getAlias() {
-        return Optional.ofNullable(authenticatorConfigModel)
-            .map(AuthenticatorConfigModel::getAlias)
-            .orElse("<unconfigured>");
-    }
+  String getAlias() {
+    return Optional.ofNullable(authenticatorConfigModel)
+        .map(AuthenticatorConfigModel::getAlias)
+        .orElse("<unconfigured>");
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/EmailHomeIdpDiscovererFactory.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/EmailHomeIdpDiscovererFactory.java
@@ -1,4 +1,4 @@
-//package de.sventorben.keycloak.authentication.hidpd.discovery.email;
+// package de.sventorben.keycloak.authentication.hidpd.discovery.email;
 package io.phasetwo.service.auth.idp.discovery.extemail;
 
 import com.google.auto.service.AutoService;
@@ -6,45 +6,39 @@ import io.phasetwo.service.auth.idp.OperationalInfo;
 import io.phasetwo.service.auth.idp.Users;
 import io.phasetwo.service.auth.idp.discovery.spi.HomeIdpDiscoverer;
 import io.phasetwo.service.auth.idp.discovery.spi.HomeIdpDiscovererFactory;
+import java.util.Map;
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ServerInfoAwareProviderFactory;
 
-import java.util.Map;
-
 @AutoService(HomeIdpDiscovererFactory.class)
-public final class EmailHomeIdpDiscovererFactory implements HomeIdpDiscovererFactory, ServerInfoAwareProviderFactory {
+public final class EmailHomeIdpDiscovererFactory
+    implements HomeIdpDiscovererFactory, ServerInfoAwareProviderFactory {
 
-    static final String PROVIDER_ID = "ext-email";
+  static final String PROVIDER_ID = "ext-email";
 
-    @Override
-    public HomeIdpDiscoverer create(KeycloakSession keycloakSession) {
-        return new EmailHomeIdpDiscoverer(new Users(keycloakSession), new DefaultIdentityProviders());
-    }
+  @Override
+  public HomeIdpDiscoverer create(KeycloakSession keycloakSession) {
+    return new EmailHomeIdpDiscoverer(new Users(keycloakSession), new DefaultIdentityProviders());
+  }
 
-    @Override
-    public void init(Config.Scope scope) {
+  @Override
+  public void init(Config.Scope scope) {}
 
-    }
+  @Override
+  public void postInit(KeycloakSessionFactory keycloakSessionFactory) {}
 
-    @Override
-    public void postInit(KeycloakSessionFactory keycloakSessionFactory) {
+  @Override
+  public void close() {}
 
-    }
+  @Override
+  public String getId() {
+    return PROVIDER_ID;
+  }
 
-    @Override
-    public void close() {
-
-    }
-
-    @Override
-    public String getId() {
-        return PROVIDER_ID;
-    }
-
-    @Override
-    public Map<String, String> getOperationalInfo() {
-        return OperationalInfo.get();
-    }
+  @Override
+  public Map<String, String> getOperationalInfo() {
+    return OperationalInfo.get();
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/EmailHomeIdpDiscoveryAuthenticatorFactoryDiscovererConfig.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/EmailHomeIdpDiscoveryAuthenticatorFactoryDiscovererConfig.java
@@ -1,21 +1,19 @@
-//package de.sventorben.keycloak.authentication.hidpd.discovery.email;
+// package de.sventorben.keycloak.authentication.hidpd.discovery.email;
 package io.phasetwo.service.auth.idp.discovery.extemail;
 
 import io.phasetwo.service.auth.idp.AbstractHomeIdpDiscoveryAuthenticatorFactory;
+import java.util.List;
 import org.keycloak.provider.ProviderConfigProperty;
 
-import java.util.List;
+public final class EmailHomeIdpDiscoveryAuthenticatorFactoryDiscovererConfig
+    implements AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig {
+  @Override
+  public List<ProviderConfigProperty> getProperties() {
+    return EmailHomeIdpDiscovererConfig.CONFIG_PROPERTIES;
+  }
 
-
-public final class EmailHomeIdpDiscoveryAuthenticatorFactoryDiscovererConfig implements AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig {
-    @Override
-    public List<ProviderConfigProperty> getProperties() {
-        return EmailHomeIdpDiscovererConfig.CONFIG_PROPERTIES;
-    }
-
-    @Override
-    public String getProviderId() {
-        return EmailHomeIdpDiscovererFactory.PROVIDER_ID;
-    }
-
+  @Override
+  public String getProviderId() {
+    return EmailHomeIdpDiscovererFactory.PROVIDER_ID;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/IdentityProviderModelConfig.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/IdentityProviderModelConfig.java
@@ -1,58 +1,55 @@
-//package de.sventorben.keycloak.authentication.hidpd;
+// package de.sventorben.keycloak.authentication.hidpd;
 package io.phasetwo.service.auth.idp.discovery.extemail;
-
-import org.keycloak.models.Constants;
-import org.keycloak.models.IdentityProviderModel;
 
 import java.util.Arrays;
 import java.util.stream.Stream;
+import org.keycloak.models.Constants;
+import org.keycloak.models.IdentityProviderModel;
 
 final class IdentityProviderModelConfig {
 
-    private static final String DOMAINS_ATTRIBUTE_KEY = "home.idp.discovery.domains";
-    private static final String SUBDOMAINS_ATTRIBUTE_KEY = "home.idp.discovery.matchSubdomains";
+  private static final String DOMAINS_ATTRIBUTE_KEY = "home.idp.discovery.domains";
+  private static final String SUBDOMAINS_ATTRIBUTE_KEY = "home.idp.discovery.matchSubdomains";
 
-    private final IdentityProviderModel identityProviderModel;
+  private final IdentityProviderModel identityProviderModel;
 
-    IdentityProviderModelConfig(IdentityProviderModel identityProviderModel) {
-        this.identityProviderModel = identityProviderModel;
+  IdentityProviderModelConfig(IdentityProviderModel identityProviderModel) {
+    this.identityProviderModel = identityProviderModel;
+  }
+
+  boolean supportsDomain(String userAttributeName, Domain domain) {
+    boolean shouldMatchSubdomains = shouldMatchSubdomains(userAttributeName);
+    return getDomains(userAttributeName)
+        .anyMatch(it -> it.equals(domain) || (shouldMatchSubdomains && domain.isSubDomainOf(it)));
+  }
+
+  private boolean shouldMatchSubdomains(String userAttributeName) {
+    String key = getSubdomainConfigKey(userAttributeName);
+    return Boolean.parseBoolean(identityProviderModel.getConfig().getOrDefault(key, "false"));
+  }
+
+  private Stream<Domain> getDomains(String userAttributeName) {
+    String key = getDomainConfigKey(userAttributeName);
+    String domainsAttribute = identityProviderModel.getConfig().getOrDefault(key, "");
+    return Arrays.stream(Constants.CFG_DELIMITER_PATTERN.split(domainsAttribute)).map(Domain::new);
+  }
+
+  private String getDomainConfigKey(String userAttributeName) {
+    return getConfigKey(DOMAINS_ATTRIBUTE_KEY, userAttributeName);
+  }
+
+  private String getSubdomainConfigKey(String userAttributeName) {
+    return getConfigKey(SUBDOMAINS_ATTRIBUTE_KEY, userAttributeName);
+  }
+
+  private String getConfigKey(String attributeKey, String userAttributeName) {
+    String key = attributeKey;
+    if (userAttributeName != null) {
+      final String candidateKey = attributeKey + "." + userAttributeName;
+      if (identityProviderModel.getConfig().containsKey(candidateKey)) {
+        key = candidateKey;
+      }
     }
-
-    boolean supportsDomain(String userAttributeName, Domain domain) {
-        boolean shouldMatchSubdomains = shouldMatchSubdomains(userAttributeName);
-        return getDomains(userAttributeName).anyMatch(it ->
-            it.equals(domain) ||
-                (shouldMatchSubdomains && domain.isSubDomainOf(it)));
-    }
-
-    private boolean shouldMatchSubdomains(String userAttributeName) {
-        String key = getSubdomainConfigKey(userAttributeName);
-        return Boolean.parseBoolean(identityProviderModel.getConfig().getOrDefault(key, "false"));
-    }
-
-    private Stream<Domain> getDomains(String userAttributeName) {
-        String key = getDomainConfigKey(userAttributeName);
-        String domainsAttribute = identityProviderModel.getConfig().getOrDefault(key, "");
-        return Arrays.stream(Constants.CFG_DELIMITER_PATTERN.split(domainsAttribute)).map(Domain::new);
-    }
-
-    private String getDomainConfigKey(String userAttributeName) {
-        return getConfigKey(DOMAINS_ATTRIBUTE_KEY, userAttributeName);
-    }
-
-    private String getSubdomainConfigKey(String userAttributeName) {
-        return getConfigKey(SUBDOMAINS_ATTRIBUTE_KEY, userAttributeName);
-    }
-
-    private String getConfigKey(String attributeKey, String userAttributeName) {
-        String key = attributeKey;
-        if (userAttributeName != null) {
-            final String candidateKey = attributeKey + "." + userAttributeName;
-            if (identityProviderModel.getConfig().containsKey(candidateKey)) {
-                key = candidateKey;
-            }
-        }
-        return key;
-    }
-
+    return key;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/IdentityProviders.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/extemail/IdentityProviders.java
@@ -1,65 +1,67 @@
-//package de.sventorben.keycloak.authentication.hidpd.discovery.email;
+// package de.sventorben.keycloak.authentication.hidpd.discovery.email;
 package io.phasetwo.service.auth.idp.discovery.extemail;
 
 import io.phasetwo.service.auth.idp.PublicAPI;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 /**
  * Defines the contract for filtering and retrieving identity providers based on domain-specific
- * criteria within the authentication process. This interface allows for the dynamic
- * selection of identity providers (IdPs) that match certain conditions, enhancing the flexibility
- * and precision of home IdP discovery mechanisms.
- * <p>
- * Implementations of this interface should provide logic to filter identity providers based on
- * custom criteria such as the domain associated with the user or other relevant factors.
- * </p>
+ * criteria within the authentication process. This interface allows for the dynamic selection of
+ * identity providers (IdPs) that match certain conditions, enhancing the flexibility and precision
+ * of home IdP discovery mechanisms.
  *
- * to changes in future releases.
+ * <p>Implementations of this interface should provide logic to filter identity providers based on
+ * custom criteria such as the domain associated with the user or other relevant factors. to changes
+ * in future releases.
  */
 @PublicAPI(unstable = true)
 public interface IdentityProviders {
 
-    Logger LOG = Logger.getLogger(IdentityProviders.class);
+  Logger LOG = Logger.getLogger(IdentityProviders.class);
 
-    /**
-     * Filters the given list of identity provider candidates to return those that match a specified
-     * domain within the context of an authentication flow.
-     *
-     * @param context The authentication flow context providing runtime information about the
-     *                current authentication process.
-     * @param candidates A list of potentially eligible identity providers that may be suitable
-     *                   for the user based on initial criteria (see {@code #candidatesForHomeIdp}).
-     * @param domain The domain criteria used to match identity providers.
-     * @return A filtered list of {@link IdentityProviderModel} that match the specified domain criteria.
-     * May be empty but not {@code null}.
-     */
-    List<IdentityProviderModel> withMatchingDomain(AuthenticationFlowContext context, List<IdentityProviderModel> candidates, Domain domain);
+  /**
+   * Filters the given list of identity provider candidates to return those that match a specified
+   * domain within the context of an authentication flow.
+   *
+   * @param context The authentication flow context providing runtime information about the current
+   *     authentication process.
+   * @param candidates A list of potentially eligible identity providers that may be suitable for
+   *     the user based on initial criteria (see {@code #candidatesForHomeIdp}).
+   * @param domain The domain criteria used to match identity providers.
+   * @return A filtered list of {@link IdentityProviderModel} that match the specified domain
+   *     criteria. May be empty but not {@code null}.
+   */
+  List<IdentityProviderModel> withMatchingDomain(
+      AuthenticationFlowContext context, List<IdentityProviderModel> candidates, Domain domain);
 
-    /**
-     * Retrieves a list of identity providers that are candidates for being the user's home IdP.
-     * <p>
-     * This default method filters out and collects only those providers that are enabled.
-     *</p>
-     * @param context The authentication flow context providing runtime information about the
-     *                current authentication process.
-     * @return A list of {@link IdentityProviderModel} from the realm. May be empty but not {@code null}.
-     */
-    default List<IdentityProviderModel> candidatesForHomeIdp(AuthenticationFlowContext context, UserModel user) {
-        RealmModel realm = context.getRealm();
-        List<IdentityProviderModel> enabledIdps = realm.getIdentityProvidersStream()
+  /**
+   * Retrieves a list of identity providers that are candidates for being the user's home IdP.
+   *
+   * <p>This default method filters out and collects only those providers that are enabled.
+   *
+   * @param context The authentication flow context providing runtime information about the current
+   *     authentication process.
+   * @return A list of {@link IdentityProviderModel} from the realm. May be empty but not {@code
+   *     null}.
+   */
+  default List<IdentityProviderModel> candidatesForHomeIdp(
+      AuthenticationFlowContext context, UserModel user) {
+    RealmModel realm = context.getRealm();
+    List<IdentityProviderModel> enabledIdps =
+        realm
+            .getIdentityProvidersStream()
             .filter(IdentityProviderModel::isEnabled)
             .collect(Collectors.toList());
-        LOG.tracef("Enabled IdPs in realm '%s': %s",
-            realm.getName(),
-            enabledIdps.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(",")));
-        return enabledIdps;
-    }
-
+    LOG.tracef(
+        "Enabled IdPs in realm '%s': %s",
+        realm.getName(),
+        enabledIdps.stream().map(IdentityProviderModel::getAlias).collect(Collectors.joining(",")));
+    return enabledIdps;
+  }
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/spi/HomeIdpDiscoverer.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/spi/HomeIdpDiscoverer.java
@@ -1,62 +1,57 @@
-//package de.sventorben.keycloak.authentication.hidpd.discovery.spi;
+// package de.sventorben.keycloak.authentication.hidpd.discovery.spi;
 package io.phasetwo.service.auth.idp.discovery.spi;
 
-//import de.sventorben.keycloak.authentication.hidpd.PublicAPI;
+// import de.sventorben.keycloak.authentication.hidpd.PublicAPI;
 import io.phasetwo.service.auth.idp.PublicAPI;
+import java.util.List;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.provider.Provider;
 
-import java.util.List;
-
 /**
- * The {@link HomeIdpDiscoverer} defines the contract for implementations
- * responsible for discovering the Home Identity Provider(s) for a given user.
- * This interface is a part of the Service Provider Interface (SPI) extension for the
- * Home IdP Discovery Keycloak extension, aimed at enabling dynamic discovery of a user's
- * Home IdP based on custom logic and criteria.
- * <p>
- * Implementations of this interface should provide the logic to determine the appropriate
- * Home IdP(s) for a user, potentially based on attributes such as the username, domain, or
- * other identifiers associated with the user's account. This is particularly useful in
- * scenarios where users may belong to different IdPs based on their organization, domain,
- * or other factors, and an automated method is required to direct the user to their
- * respective IdP for authentication.
- * </p>
- **
+ * The {@link HomeIdpDiscoverer} defines the contract for implementations responsible for
+ * discovering the Home Identity Provider(s) for a given user. This interface is a part of the
+ * Service Provider Interface (SPI) extension for the Home IdP Discovery Keycloak extension, aimed
+ * at enabling dynamic discovery of a user's Home IdP based on custom logic and criteria.
+ *
+ * <p>Implementations of this interface should provide the logic to determine the appropriate Home
+ * IdP(s) for a user, potentially based on attributes such as the username, domain, or other
+ * identifiers associated with the user's account. This is particularly useful in scenarios where
+ * users may belong to different IdPs based on their organization, domain, or other factors, and an
+ * automated method is required to direct the user to their respective IdP for authentication. *
+ *
  * @see IdentityProviderModel
  * @see AuthenticationFlowContext
  */
 @PublicAPI(unstable = true)
 public interface HomeIdpDiscoverer extends Provider {
 
-    /**
-     * Discovers and returns a list of {@link IdentityProviderModel} instances representing
-     * the Home Identity Provider(s) for the specified user. The method takes the username
-     * of the user as a parameter and returns a list of IdP models that are considered the
-     * user's home IdPs. If no home IdP is found for the user, this method may return an
-     * empty list.
-     * <p>
-     * Implementors should ensure that the logic for discovering the home IdPs is efficient
-     * and accounts for various criteria that may determine the user's Home IdP(s). The
-     * criteria and the discovery logic are dependent on the specific implementation.
-     * </p>
-     * @param context the {@link AuthenticationFlowContext} providing the current state and parameters
-     *                of the authentication flow. This context can include various details such as the
-     *                client, session, and other relevant information that can be utilized to determine
-     *                the most appropriate home IdP(s) for the user. Implementors can use this context
-     *                to access additional attributes or perform more complex logic based on the current
-     *                authentication flow.
-     * @param username the unvalidated username provided by the user, serving as the primary identifier
-     *                 for the discovery of the user's Home IdP(s). Given that this username is unvalidated
-     *                 input, implementors should apply appropriate validation or sanitization measures
-     *                 to mitigate potential security risks or logic errors. This consideration is
-     *                 crucial, especially in scenarios where multiple users across different realms or
-     *                 IdPs might share the same username, necessitating the use of the authentication
-     *                 flow context to resolve such ambiguities.
-     * @return a list of {@link IdentityProviderModel} instances representing the discovered
-     *         home IdP(s) for the user. The list may be empty if no home IdP is associated
-     *         with the user. Do not return {@code null}.
-     */
-    List<IdentityProviderModel> discoverForUser(AuthenticationFlowContext context, String username);
+  /**
+   * Discovers and returns a list of {@link IdentityProviderModel} instances representing the Home
+   * Identity Provider(s) for the specified user. The method takes the username of the user as a
+   * parameter and returns a list of IdP models that are considered the user's home IdPs. If no home
+   * IdP is found for the user, this method may return an empty list.
+   *
+   * <p>Implementors should ensure that the logic for discovering the home IdPs is efficient and
+   * accounts for various criteria that may determine the user's Home IdP(s). The criteria and the
+   * discovery logic are dependent on the specific implementation.
+   *
+   * @param context the {@link AuthenticationFlowContext} providing the current state and parameters
+   *     of the authentication flow. This context can include various details such as the client,
+   *     session, and other relevant information that can be utilized to determine the most
+   *     appropriate home IdP(s) for the user. Implementors can use this context to access
+   *     additional attributes or perform more complex logic based on the current authentication
+   *     flow.
+   * @param username the unvalidated username provided by the user, serving as the primary
+   *     identifier for the discovery of the user's Home IdP(s). Given that this username is
+   *     unvalidated input, implementors should apply appropriate validation or sanitization
+   *     measures to mitigate potential security risks or logic errors. This consideration is
+   *     crucial, especially in scenarios where multiple users across different realms or IdPs might
+   *     share the same username, necessitating the use of the authentication flow context to
+   *     resolve such ambiguities.
+   * @return a list of {@link IdentityProviderModel} instances representing the discovered home
+   *     IdP(s) for the user. The list may be empty if no home IdP is associated with the user. Do
+   *     not return {@code null}.
+   */
+  List<IdentityProviderModel> discoverForUser(AuthenticationFlowContext context, String username);
 }

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/spi/HomeIdpDiscovererFactory.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/spi/HomeIdpDiscovererFactory.java
@@ -1,10 +1,8 @@
-//package de.sventorben.keycloak.authentication.hidpd.discovery.spi;
+// package de.sventorben.keycloak.authentication.hidpd.discovery.spi;
 package io.phasetwo.service.auth.idp.discovery.spi;
 
 import io.phasetwo.service.auth.idp.PublicAPI;
 import org.keycloak.provider.ProviderFactory;
 
-
 @PublicAPI(unstable = true)
-public interface HomeIdpDiscovererFactory extends ProviderFactory<HomeIdpDiscoverer> {
-}
+public interface HomeIdpDiscovererFactory extends ProviderFactory<HomeIdpDiscoverer> {}

--- a/src/main/java/io/phasetwo/service/auth/idp/discovery/spi/HomeIdpDiscoverySpi.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/discovery/spi/HomeIdpDiscoverySpi.java
@@ -1,4 +1,4 @@
-//package de.sventorben.keycloak.authentication.hidpd.discovery.spi;
+// package de.sventorben.keycloak.authentication.hidpd.discovery.spi;
 package io.phasetwo.service.auth.idp.discovery.spi;
 
 import com.google.auto.service.AutoService;
@@ -9,25 +9,25 @@ import org.keycloak.provider.Spi;
 @AutoService(Spi.class)
 public final class HomeIdpDiscoverySpi implements Spi {
 
-    private static final String SPI_NAME = "ext-hidpd-discovery";
+  private static final String SPI_NAME = "ext-hidpd-discovery";
 
-    @Override
-    public boolean isInternal() {
-        return true;
-    }
+  @Override
+  public boolean isInternal() {
+    return true;
+  }
 
-    @Override
-    public String getName() {
-        return SPI_NAME;
-    }
+  @Override
+  public String getName() {
+    return SPI_NAME;
+  }
 
-    @Override
-    public Class<? extends Provider> getProviderClass() {
-        return HomeIdpDiscoverer.class;
-    }
+  @Override
+  public Class<? extends Provider> getProviderClass() {
+    return HomeIdpDiscoverer.class;
+  }
 
-    @Override
-    public Class<? extends ProviderFactory<HomeIdpDiscoverer>> getProviderFactoryClass() {
-        return HomeIdpDiscovererFactory.class;
-    }
+  @Override
+  public Class<? extends ProviderFactory<HomeIdpDiscoverer>> getProviderFactoryClass() {
+    return HomeIdpDiscovererFactory.class;
+  }
 }

--- a/src/main/java/io/phasetwo/service/importexport/KeycloakOrgsExportConverter.java
+++ b/src/main/java/io/phasetwo/service/importexport/KeycloakOrgsExportConverter.java
@@ -92,8 +92,8 @@ public final class KeycloakOrgsExportConverter {
     return role;
   }
 
-  private static OrganizationImportRepresentation convertOrganizationModelToOrganizationImportRepresentation(
-      OrganizationModel e) {
+  private static OrganizationImportRepresentation
+      convertOrganizationModelToOrganizationImportRepresentation(OrganizationModel e) {
     var o = new OrganizationImportRepresentation();
 
     o.setName(e.getName());

--- a/src/main/java/io/phasetwo/service/importexport/representation/OrganizationImportRepresentation.java
+++ b/src/main/java/io/phasetwo/service/importexport/representation/OrganizationImportRepresentation.java
@@ -7,10 +7,10 @@ import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import io.phasetwo.service.util.EmptyStringAsNullDeserializer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import io.phasetwo.service.util.EmptyStringAsNullDeserializer;
 import lombok.Data;
 
 @Data

--- a/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java
+++ b/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java
@@ -107,9 +107,9 @@ public class JpaOrganizationProvider implements OrganizationProvider {
   public Stream<OrganizationModel> getOrganizationsStreamForDomain(
       RealmModel realm, String domain, boolean verified) {
     try {
-       domain = InternetDomainName.from(domain).toString();
-    } catch (IllegalArgumentException e){
-       return Stream.empty();
+      domain = InternetDomainName.from(domain).toString();
+    } catch (IllegalArgumentException e) {
+      return Stream.empty();
     }
 
     TypedQuery<DomainEntity> query =

--- a/src/main/java/io/phasetwo/service/resource/Converters.java
+++ b/src/main/java/io/phasetwo/service/resource/Converters.java
@@ -2,13 +2,13 @@ package io.phasetwo.service.resource;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import io.phasetwo.service.scim.ComponentScimConfig;
-import io.phasetwo.service.util.Argon2idEncoder;
 import io.phasetwo.service.model.InvitationModel;
 import io.phasetwo.service.model.OrganizationModel;
 import io.phasetwo.service.model.OrganizationRoleModel;
 import io.phasetwo.service.model.jpa.entity.InvitationEntity;
 import io.phasetwo.service.representation.*;
+import io.phasetwo.service.scim.ComponentScimConfig;
+import io.phasetwo.service.util.Argon2idEncoder;
 import java.util.List;
 import java.util.Map;
 import org.keycloak.component.ComponentModel;

--- a/src/main/java/io/phasetwo/service/resource/ScimProviderResource.java
+++ b/src/main/java/io/phasetwo/service/resource/ScimProviderResource.java
@@ -29,9 +29,9 @@ public class ScimProviderResource extends OrganizationAdminResource {
   }
 
   /**
-   * If the realm-level SCIM feature flag is disabled, the entire resource pretends
-   * not to exist (404). The flag defaults to false; flip it on via the
-   * Organization Settings UI or {@code /realms/{realm}/orgs/config}.
+   * If the realm-level SCIM feature flag is disabled, the entire resource pretends not to exist
+   * (404). The flag defaults to false; flip it on via the Organization Settings UI or {@code
+   * /realms/{realm}/orgs/config}.
    */
   private void requireScimEnabled() {
     if (!session.getContext().getRealm().getAttribute(ORG_CONFIG_SCIM_ENABLED_KEY, false)) {
@@ -78,8 +78,7 @@ public class ScimProviderResource extends OrganizationAdminResource {
           .build();
     }
 
-    ComponentScimConfig newConfig =
-        convertRepresentationToScimConfig(rep);
+    ComponentScimConfig newConfig = convertRepresentationToScimConfig(rep);
     ComponentScimConfig created =
         configProvider.createConfiguration(organization.getId(), newConfig);
 
@@ -112,8 +111,7 @@ public class ScimProviderResource extends OrganizationAdminResource {
       throw new NotFoundException("No SCIM configuration found for organization");
     }
 
-    ComponentScimConfig updateConfig =
-        convertRepresentationToScimConfig(rep);
+    ComponentScimConfig updateConfig = convertRepresentationToScimConfig(rep);
     ComponentScimConfig updated =
         configProvider.updateConfiguration(organization.getId(), updateConfig);
 

--- a/src/main/java/io/phasetwo/service/scim/PhasetwoOrganizationScimServerProvider.java
+++ b/src/main/java/io/phasetwo/service/scim/PhasetwoOrganizationScimServerProvider.java
@@ -65,8 +65,7 @@ public class PhasetwoOrganizationScimServerProvider implements OrganizationScimS
                 String.format(
                     "realms/%s/scim/v2/organizations/%s/", realm.getName(), organization.getId()));
 
-    ScimConfigurationProvider configProvider =
-        session.getProvider(ScimConfigurationProvider.class);
+    ScimConfigurationProvider configProvider = session.getProvider(ScimConfigurationProvider.class);
     ComponentScimConfig config = configProvider.getConfiguration(organizationId);
     if (config == null) {
       throw new NotFoundException(organizationId + " has no SCIM configuration");

--- a/src/main/java/io/phasetwo/service/scim/federation/OrgScimUserStorageProvider.java
+++ b/src/main/java/io/phasetwo/service/scim/federation/OrgScimUserStorageProvider.java
@@ -5,20 +5,15 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.storage.UserStorageProvider;
 
 /**
- * Empty UserStorageProvider. Its existence makes
- * {@link OrgScimUserStorageProviderFactory} a valid registered
- * {@link org.keycloak.storage.UserStorageProviderFactory}, which is
- * what Keycloak's {@code realm.addComponentModel} requires to accept
- * the {@code ComponentModel}s used for per-organization SCIM
- * configuration storage.
+ * Empty UserStorageProvider. Its existence makes {@link OrgScimUserStorageProviderFactory} a valid
+ * registered {@link org.keycloak.storage.UserStorageProviderFactory}, which is what Keycloak's
+ * {@code realm.addComponentModel} requires to accept the {@code ComponentModel}s used for
+ * per-organization SCIM configuration storage.
  *
- * <p>This provider itself does nothing at runtime; the SCIM config
- * data is read/written by
- * {@link io.phasetwo.service.scim.spi.DefaultScimConfigurationProvider}
- * directly against the realm's components container. Per-organization
- * SCIM configuration is normally managed through the
- * {@code /{realm}/orgs/{orgId}/scim} REST endpoint and the Admin UI
- * tab exposed by keycloak-themes.
+ * <p>This provider itself does nothing at runtime; the SCIM config data is read/written by {@link
+ * io.phasetwo.service.scim.spi.DefaultScimConfigurationProvider} directly against the realm's
+ * components container. Per-organization SCIM configuration is normally managed through the {@code
+ * /{realm}/orgs/{orgId}/scim} REST endpoint and the Admin UI tab exposed by keycloak-themes.
  */
 public class OrgScimUserStorageProvider implements UserStorageProvider {
 

--- a/src/main/java/io/phasetwo/service/scim/federation/OrgScimUserStorageProviderFactory.java
+++ b/src/main/java/io/phasetwo/service/scim/federation/OrgScimUserStorageProviderFactory.java
@@ -14,27 +14,23 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.storage.UserStorageProviderFactory;
 
 /**
- * Registers an "Organization SCIM" User Federation provider. Its sole
- * purpose is to make Keycloak's ComponentModel infrastructure accept
- * SCIM-config persistence: the SCIM-tab REST endpoint creates a
- * {@code ComponentModel} with
- * {@code providerType=org.keycloak.storage.UserStorageProvider} and
- * {@code providerId="Organization SCIM"}, and Keycloak validates that
- * combo against a registered factory at add/update time.
+ * Registers an "Organization SCIM" User Federation provider. Its sole purpose is to make Keycloak's
+ * ComponentModel infrastructure accept SCIM-config persistence: the SCIM-tab REST endpoint creates
+ * a {@code ComponentModel} with {@code providerType=org.keycloak.storage.UserStorageProvider} and
+ * {@code providerId="Organization SCIM"}, and Keycloak validates that combo against a registered
+ * factory at add/update time.
  *
- * <p>Side effect: the entry appears in the Keycloak Admin Console's
- * User Federation page. That's accepted as a cosmetic compromise — the
- * canonical UI for managing SCIM configs is the per-org SCIM tab.
+ * <p>Side effect: the entry appears in the Keycloak Admin Console's User Federation page. That's
+ * accepted as a cosmetic compromise — the canonical UI for managing SCIM configs is the per-org
+ * SCIM tab.
  *
- * <p>An earlier iteration tried to gate this factory behind
- * {@code EnvironmentDependentProviderFactory#isSupported} so it could
- * be hidden from the User Federation list by default, but that broke
- * storage entirely (no registered factory means
- * {@code realm.addComponentModel} throws "No such provider"). Hiding
- * just the UI listing without breaking storage would require turning
- * {@code ScimConfigurationProviderFactory} into a full
- * {@link org.keycloak.component.ComponentFactory} and switching the
- * storage providerType to our SPI's FQCN.
+ * <p>An earlier iteration tried to gate this factory behind {@code
+ * EnvironmentDependentProviderFactory#isSupported} so it could be hidden from the User Federation
+ * list by default, but that broke storage entirely (no registered factory means {@code
+ * realm.addComponentModel} throws "No such provider"). Hiding just the UI listing without breaking
+ * storage would require turning {@code ScimConfigurationProviderFactory} into a full {@link
+ * org.keycloak.component.ComponentFactory} and switching the storage providerType to our SPI's
+ * FQCN.
  */
 @SuppressWarnings("rawtypes")
 @JBossLog

--- a/src/main/java/io/phasetwo/service/scim/spi/DefaultScimConfigurationProvider.java
+++ b/src/main/java/io/phasetwo/service/scim/spi/DefaultScimConfigurationProvider.java
@@ -5,9 +5,7 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 
-/**
- * Default implementation of ScimConfigurationProvider backed by Keycloak ComponentModel.
- */
+/** Default implementation of ScimConfigurationProvider backed by Keycloak ComponentModel. */
 public class DefaultScimConfigurationProvider implements ScimConfigurationProvider {
 
   private final KeycloakSession session;
@@ -91,14 +89,12 @@ public class DefaultScimConfigurationProvider implements ScimConfigurationProvid
   private void copyConfigToModel(ComponentModel target, ComponentScimConfig source) {
     if (source.getAuthenticationMode() != null) {
       target.put(
-          ComponentScimConfig.SCIM_AUTHENTICATION_MODE,
-          source.getAuthenticationMode().name());
+          ComponentScimConfig.SCIM_AUTHENTICATION_MODE, source.getAuthenticationMode().name());
     }
     setOrRemove(target, ComponentScimConfig.SCIM_EXTERNAL_ISSUER, source.getExternalIssuer());
     setOrRemove(target, ComponentScimConfig.SCIM_EXTERNAL_AUDIENCE, source.getExternalAudience());
     setOrRemove(target, ComponentScimConfig.SCIM_EXTERNAL_JWKS_URI, source.getExternalJwksUri());
-    setOrRemove(
-        target, ComponentScimConfig.SCIM_EXTERNAL_SHARED_SECRET, source.getSharedSecret());
+    setOrRemove(target, ComponentScimConfig.SCIM_EXTERNAL_SHARED_SECRET, source.getSharedSecret());
     setOrRemove(
         target, ComponentScimConfig.SCIM_BASIC_AUTH_USERNAME, source.getBasicAuthUsername());
     setOrRemove(

--- a/src/main/java/io/phasetwo/service/scim/spi/ScimConfigurationProvider.java
+++ b/src/main/java/io/phasetwo/service/scim/spi/ScimConfigurationProvider.java
@@ -4,8 +4,8 @@ import io.phasetwo.service.scim.ComponentScimConfig;
 import org.keycloak.provider.Provider;
 
 /**
- * SPI for managing per-organization SCIM configurations.
- * Abstracts away the underlying persistence mechanism.
+ * SPI for managing per-organization SCIM configurations. Abstracts away the underlying persistence
+ * mechanism.
  */
 public interface ScimConfigurationProvider extends Provider {
 

--- a/src/main/java/io/phasetwo/service/util/Argon2idEncoder.java
+++ b/src/main/java/io/phasetwo/service/util/Argon2idEncoder.java
@@ -29,16 +29,14 @@ public final class Argon2idEncoder {
 
   private Argon2idEncoder() {}
 
-  /**
-   * Returns true if the given value already looks like a PHC-formatted argon2 string.
-   */
+  /** Returns true if the given value already looks like a PHC-formatted argon2 string. */
   public static boolean isAlreadyHashed(String value) {
     return value != null && value.startsWith(PHC_PREFIX);
   }
 
   /**
-   * Encodes the given cleartext value into a PHC-formatted argon2id hash.
-   * Returns the input unchanged if it already looks like a PHC string.
+   * Encodes the given cleartext value into a PHC-formatted argon2id hash. Returns the input
+   * unchanged if it already looks like a PHC string.
    */
   public static String encode(String cleartext) {
     if (cleartext == null || cleartext.isEmpty() || isAlreadyHashed(cleartext)) {
@@ -65,7 +63,10 @@ public final class Argon2idEncoder {
 
     return String.format(
         "$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
-        VERSION, MEMORY_KB, ITERATIONS, PARALLELISM,
+        VERSION,
+        MEMORY_KB,
+        ITERATIONS,
+        PARALLELISM,
         ENCODER.encodeToString(salt),
         ENCODER.encodeToString(hash));
   }

--- a/src/main/java/io/phasetwo/service/util/EmptyStringAsNullDeserializer.java
+++ b/src/main/java/io/phasetwo/service/util/EmptyStringAsNullDeserializer.java
@@ -4,17 +4,16 @@ import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-
 import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Predicate;
 
 public class EmptyStringAsNullDeserializer extends JsonDeserializer<String> {
-    @Override
-    public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
-        return Optional
-                .ofNullable(p.getValueAsString())
-                .filter(Predicate.not(String::isEmpty))
-                .orElse(null);
-    }
+  @Override
+  public String deserialize(JsonParser p, DeserializationContext ctxt)
+      throws IOException, JacksonException {
+    return Optional.ofNullable(p.getValueAsString())
+        .filter(Predicate.not(String::isEmpty))
+        .orElse(null);
+  }
 }

--- a/src/test/java/io/phasetwo/service/AbstractOrganizationTest.java
+++ b/src/test/java/io/phasetwo/service/AbstractOrganizationTest.java
@@ -23,7 +23,6 @@ import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.phasetwo.client.openapi.model.OrganizationRepresentation;
 import io.phasetwo.client.openapi.model.OrganizationRoleRepresentation;
 import io.phasetwo.keycloak.events.MdcLoggerEventStoreProviderFactory;
-import io.phasetwo.service.KeycloakOrgsAdminAPI;
 import io.phasetwo.service.importexport.representation.InvitationRepresentation;
 import io.phasetwo.service.importexport.representation.KeycloakOrgsRepresentation;
 import io.phasetwo.service.importexport.representation.UserRolesRepresentation;
@@ -101,11 +100,11 @@ public abstract class AbstractOrganizationTest {
           .withExposedPorts(8787, 9000, 8080)
           .withProviderLibsFrom(getDeps())
           .withCustomCommand(
-                  "--spi-events-store-provider=" + MdcLoggerEventStoreProviderFactory.PROVIDER_ID)
+              "--spi-events-store-provider=" + MdcLoggerEventStoreProviderFactory.PROVIDER_ID)
           .withCustomCommand(
-                  "--spi-events-store-"
-                          + MdcLoggerEventStoreProviderFactory.PROVIDER_ID
-                          + "-use-jpa=true")
+              "--spi-events-store-"
+                  + MdcLoggerEventStoreProviderFactory.PROVIDER_ID
+                  + "-use-jpa=true")
           .withEnv(
               "JAVA_OPTS",
               "-agentlib:jdwp=transport=dt_socket,address=*:8787,server=y,suspend=n -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m ")

--- a/src/test/java/io/phasetwo/service/globalconfig/ScimFeatureFlagTest.java
+++ b/src/test/java/io/phasetwo/service/globalconfig/ScimFeatureFlagTest.java
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies the realm-level SCIM feature flag exposed at
- * {@code PUT/GET /realms/{realm}/orgs/config}.
+ * Verifies the realm-level SCIM feature flag exposed at {@code PUT/GET
+ * /realms/{realm}/orgs/config}.
  */
 @JBossLog
 public class ScimFeatureFlagTest extends AbstractOrganizationTest {

--- a/src/test/java/io/phasetwo/service/importexport/OrganizationImportWithDatabaseAccessTest.java
+++ b/src/test/java/io/phasetwo/service/importexport/OrganizationImportWithDatabaseAccessTest.java
@@ -10,13 +10,11 @@ import static org.hamcrest.Matchers.is;
 import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.phasetwo.service.importexport.representation.KeycloakOrgsRepresentation;
 import jakarta.ws.rs.core.Response;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -32,136 +30,136 @@ import org.testcontainers.containers.PostgreSQLContainer;
  * environment, along with database query validations. This test class uses a PostgreSQL container
  * and Keycloak container as part of its test setup.
  *
- *  The tests primarily focus on:
- * - Importing a realm into Keycloak.
- * - Importing organizations into the realm.
- * - Validating the database to ensure the imported organizations are correctly added.
+ * <p>The tests primarily focus on: - Importing a realm into Keycloak. - Importing organizations
+ * into the realm. - Validating the database to ensure the imported organizations are correctly
+ * added.
  *
- * With these validations, the test ensures that we store what we expect in the database, and there's no hidden
- * error in the API-level conversions
- *
+ * <p>With these validations, the test ensures that we store what we expect in the database, and
+ * there's no hidden error in the API-level conversions
  */
 @DisplayName("Tests for the Organization import endpoints with database-query verifications")
 public class OrganizationImportWithDatabaseAccessTest {
 
-    private static Network network = Network.newNetwork();
+  private static Network network = Network.newNetwork();
 
-    private static final PostgreSQLContainer<?> postgres =
-            new PostgreSQLContainer<>("postgres:16")
-                    .withNetwork(network)
-                    .withNetworkAliases("postgres")
-                    .withDatabaseName("keycloak")
-                    .withUsername("keycloak")
-                    .withPassword("password");
+  private static final PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>("postgres:16")
+          .withNetwork(network)
+          .withNetworkAliases("postgres")
+          .withDatabaseName("keycloak")
+          .withUsername("keycloak")
+          .withPassword("password");
 
-    private static KeycloakContainer keycloakContainer =
-            new KeycloakContainer(KEYCLOAK_IMAGE)
-                    .withNetwork(network)
-                    .withContextPath("/auth")
-                    .withProviderClassesFrom("target/classes")
-                    .withProviderLibsFrom(getDeps())
-                    .withEnv("KC_DB", "postgres")
-                    .withEnv("KC_DB_URL", "jdbc:postgresql://postgres:5432/keycloak?loggerLevel=OFF")
-                    .withEnv("KC_DB_USERNAME", postgres.getUsername())
-                    .withEnv("KC_DB_PASSWORD", postgres.getPassword())
-                    .withAccessToHost(true);
-    private static Keycloak keycloak;
+  private static KeycloakContainer keycloakContainer =
+      new KeycloakContainer(KEYCLOAK_IMAGE)
+          .withNetwork(network)
+          .withContextPath("/auth")
+          .withProviderClassesFrom("target/classes")
+          .withProviderLibsFrom(getDeps())
+          .withEnv("KC_DB", "postgres")
+          .withEnv("KC_DB_URL", "jdbc:postgresql://postgres:5432/keycloak?loggerLevel=OFF")
+          .withEnv("KC_DB_USERNAME", postgres.getUsername())
+          .withEnv("KC_DB_PASSWORD", postgres.getPassword())
+          .withAccessToHost(true);
+  private static Keycloak keycloak;
 
-    @BeforeAll
-    public static void setUp() {
-        postgres.start();
-        keycloakContainer.start();
+  @BeforeAll
+  public static void setUp() {
+    postgres.start();
+    keycloakContainer.start();
 
-        keycloak =
-                Keycloak.getInstance(
-                        keycloakContainer.getAuthServerUrl(),
-                        "master",
-                        keycloakContainer.getAdminUsername(),
-                        keycloakContainer.getAdminPassword(),
-                        "admin-cli");
+    keycloak =
+        Keycloak.getInstance(
+            keycloakContainer.getAuthServerUrl(),
+            "master",
+            keycloakContainer.getAdminUsername(),
+            keycloakContainer.getAdminPassword(),
+            "admin-cli");
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    if (keycloakContainer != null) {
+      keycloakContainer.stop();
     }
-
-    @AfterAll
-    public static void tearDown() {
-        if (keycloakContainer != null) {
-            keycloakContainer.stop();
-        }
-        if (postgres != null) {
-            postgres.stop();
-        }
-        if (network != null) {
-            network.close();
-        }
+    if (postgres != null) {
+      postgres.stop();
     }
-
-    @Test
-    @DisplayName("Import organization with empty string as domain and verify that the empty domain is not stored in the database")
-    void testOrganizationWithEmptyDomainImportAndVerifyInDatabase() throws SQLException {
-        String realmName = "test-realm";
-
-        // 1. Import Realm
-        RealmRepresentation testRealm =
-                loadJson(
-                        OrganizationImportWithDatabaseAccessTest.class.getResourceAsStream(
-                                "/orgs/keycloak-realm-with-identity-provider.json"),
-                        RealmRepresentation.class);
-        testRealm.setRealm(realmName);
-
-        var realmResponse =
-                given()
-                        .baseUri(keycloakContainer.getAuthServerUrl())
-                        .basePath("admin/realms/")
-                        .contentType("application/json")
-                        .auth()
-                        .oauth2(keycloak.tokenManager().getAccessTokenString())
-                        .and()
-                        .body(testRealm)
-                        .when()
-                        .post()
-                        .then()
-                        .extract()
-                        .response();
-        assertThat(realmResponse.getStatusCode(), CoreMatchers.is(Response.Status.CREATED.getStatusCode()));
-
-        // 2. Import Organization
-        KeycloakOrgsRepresentation orgsRepresentation =
-                loadJson(
-                        OrganizationImportWithDatabaseAccessTest.class.getResourceAsStream(
-                                "/orgs/org-import-test.json"),
-                        KeycloakOrgsRepresentation.class);
-
-        var orgsResponse =
-                given()
-                        .baseUri(keycloakContainer.getAuthServerUrl())
-                        .basePath("realms/" + realmName + "/orgs")
-                        .contentType("application/json")
-                        .auth()
-                        .oauth2(keycloak.tokenManager().getAccessTokenString())
-                        .queryParam("skipMissingMember", false)
-                        .queryParam("skipMissingIdp", false)
-                        .when()
-                        .and()
-                        .body(orgsRepresentation)
-                        .when()
-                        .post("import")
-                        .then()
-                        .extract()
-                        .response();
-        assertThat(orgsResponse.getStatusCode(), CoreMatchers.is(Response.Status.OK.getStatusCode()));
-
-        // 3. Verify in Database
-        try (Connection conn =
-                     DriverManager.getConnection(
-                             postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
-             Statement stmt = conn.createStatement()) {
-
-            ResultSet rs = stmt.executeQuery("SELECT count(*) FROM ORGANIZATION WHERE NAME = 'test1'");
-            rs.next();
-            assertThat("Organization test1 should exist in database", rs.getInt(1), is(1));
-
-            rs = stmt.executeQuery("SELECT count(*) FROM ORGANIZATION_DOMAIN WHERE domain = ''");
-            rs.next();
-            assertThat("There should be no empty string domains in the database", rs.getInt(1), is(0));
-        }
+    if (network != null) {
+      network.close();
     }
+  }
+
+  @Test
+  @DisplayName(
+      "Import organization with empty string as domain and verify that the empty domain is not stored in the database")
+  void testOrganizationWithEmptyDomainImportAndVerifyInDatabase() throws SQLException {
+    String realmName = "test-realm";
+
+    // 1. Import Realm
+    RealmRepresentation testRealm =
+        loadJson(
+            OrganizationImportWithDatabaseAccessTest.class.getResourceAsStream(
+                "/orgs/keycloak-realm-with-identity-provider.json"),
+            RealmRepresentation.class);
+    testRealm.setRealm(realmName);
+
+    var realmResponse =
+        given()
+            .baseUri(keycloakContainer.getAuthServerUrl())
+            .basePath("admin/realms/")
+            .contentType("application/json")
+            .auth()
+            .oauth2(keycloak.tokenManager().getAccessTokenString())
+            .and()
+            .body(testRealm)
+            .when()
+            .post()
+            .then()
+            .extract()
+            .response();
+    assertThat(
+        realmResponse.getStatusCode(), CoreMatchers.is(Response.Status.CREATED.getStatusCode()));
+
+    // 2. Import Organization
+    KeycloakOrgsRepresentation orgsRepresentation =
+        loadJson(
+            OrganizationImportWithDatabaseAccessTest.class.getResourceAsStream(
+                "/orgs/org-import-test.json"),
+            KeycloakOrgsRepresentation.class);
+
+    var orgsResponse =
+        given()
+            .baseUri(keycloakContainer.getAuthServerUrl())
+            .basePath("realms/" + realmName + "/orgs")
+            .contentType("application/json")
+            .auth()
+            .oauth2(keycloak.tokenManager().getAccessTokenString())
+            .queryParam("skipMissingMember", false)
+            .queryParam("skipMissingIdp", false)
+            .when()
+            .and()
+            .body(orgsRepresentation)
+            .when()
+            .post("import")
+            .then()
+            .extract()
+            .response();
+    assertThat(orgsResponse.getStatusCode(), CoreMatchers.is(Response.Status.OK.getStatusCode()));
+
+    // 3. Verify in Database
+    try (Connection conn =
+            DriverManager.getConnection(
+                postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+        Statement stmt = conn.createStatement()) {
+
+      ResultSet rs = stmt.executeQuery("SELECT count(*) FROM ORGANIZATION WHERE NAME = 'test1'");
+      rs.next();
+      assertThat("Organization test1 should exist in database", rs.getInt(1), is(1));
+
+      rs = stmt.executeQuery("SELECT count(*) FROM ORGANIZATION_DOMAIN WHERE domain = ''");
+      rs.next();
+      assertThat("There should be no empty string domains in the database", rs.getInt(1), is(0));
+    }
+  }
 }

--- a/src/test/java/io/phasetwo/service/resource/AbstractDbCompatibilityTest.java
+++ b/src/test/java/io/phasetwo/service/resource/AbstractDbCompatibilityTest.java
@@ -29,12 +29,12 @@ import org.testcontainers.images.PullPolicy;
 import org.testcontainers.utility.MountableFile;
 
 /**
- * Base class for database-compatibility smoke tests. To add support for a new database, extend
- * this class, annotate it with {@code @TestInstance(Lifecycle.PER_CLASS)}, and implement the three
+ * Base class for database-compatibility smoke tests. To add support for a new database, extend this
+ * class, annotate it with {@code @TestInstance(Lifecycle.PER_CLASS)}, and implement the three
  * abstract methods. The inherited {@code @Test} will run automatically.
  *
- * <p>Tests only execute when {@code -Dinclude.integration=true} is set (activated by the
- * {@code integration-tests} Maven profile).
+ * <p>Tests only execute when {@code -Dinclude.integration=true} is set (activated by the {@code
+ * integration-tests} Maven profile).
  */
 @JBossLog
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/io/phasetwo/service/resource/OrganizationResourceTest.java
+++ b/src/test/java/io/phasetwo/service/resource/OrganizationResourceTest.java
@@ -2561,7 +2561,8 @@ class OrganizationResourceTest extends AbstractOrganizationTest {
       // Get the list of roles to verify the delete-organization role exists by default
       Response response = getRequest(orgId);
       assertThat(response.getStatusCode(), is(Status.OK.getStatusCode()));
-      final var orgRep = objectMapper().readValue(response.getBody().asString(), OrganizationRepresentation.class);
+      final var orgRep =
+          objectMapper().readValue(response.getBody().asString(), OrganizationRepresentation.class);
       final var currentDomainList = orgRep.getDomains();
       final var updatedDomainList = new ArrayList<>(currentDomainList);
       updatedDomainList.add("");
@@ -2572,10 +2573,14 @@ class OrganizationResourceTest extends AbstractOrganizationTest {
 
       Response responseAfterModification = getRequest(orgId);
       assertThat(responseAfterModification.getStatusCode(), is(Status.OK.getStatusCode()));
-      final var orgRepAfterModification = objectMapper().readValue(responseAfterModification.getBody().asString(), OrganizationRepresentation.class);
+      final var orgRepAfterModification =
+          objectMapper()
+              .readValue(
+                  responseAfterModification.getBody().asString(), OrganizationRepresentation.class);
       final var expectedDomains = new HashSet<>(currentDomainList);
       expectedDomains.add("vnagy.eu");
-      assertThat(orgRepAfterModification.getDomains(), containsInAnyOrder(expectedDomains.toArray()));
+      assertThat(
+          orgRepAfterModification.getDomains(), containsInAnyOrder(expectedDomains.toArray()));
     } finally {
       // Clean up
       deleteOrganization(orgId);
@@ -2593,7 +2598,8 @@ class OrganizationResourceTest extends AbstractOrganizationTest {
       // Get the list of roles to verify the delete-organization role exists by default
       Response response = getRequest(orgId);
       assertThat(response.getStatusCode(), is(Status.OK.getStatusCode()));
-      final var orgRep = objectMapper().readValue(response.getBody().asString(), OrganizationRepresentation.class);
+      final var orgRep =
+          objectMapper().readValue(response.getBody().asString(), OrganizationRepresentation.class);
       final var currentDomainList = orgRep.getDomains();
       final var updatedDomainList = new ArrayList<>(currentDomainList);
       updatedDomainList.add("");
@@ -2605,10 +2611,14 @@ class OrganizationResourceTest extends AbstractOrganizationTest {
 
       Response responseAfterModification = getRequest(orgId);
       assertThat(responseAfterModification.getStatusCode(), is(Status.OK.getStatusCode()));
-      final var orgRepAfterModification = objectMapper().readValue(responseAfterModification.getBody().asString(), OrganizationRepresentation.class);
+      final var orgRepAfterModification =
+          objectMapper()
+              .readValue(
+                  responseAfterModification.getBody().asString(), OrganizationRepresentation.class);
       final var expectedDomains = new HashSet<>(currentDomainList);
       expectedDomains.add("vnagy.eu");
-      assertThat(orgRepAfterModification.getDomains(), containsInAnyOrder(expectedDomains.toArray()));
+      assertThat(
+          orgRepAfterModification.getDomains(), containsInAnyOrder(expectedDomains.toArray()));
     } finally {
       // Clean up
       deleteOrganization(orgId);

--- a/src/test/java/io/phasetwo/service/resource/ScimProviderResourceTest.java
+++ b/src/test/java/io/phasetwo/service/resource/ScimProviderResourceTest.java
@@ -5,17 +5,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.phasetwo.client.openapi.model.OrganizationRepresentation;
 import io.phasetwo.service.AbstractOrganizationTest;
 import io.phasetwo.service.representation.*;
 import io.restassured.response.Response;
 import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
-import java.util.List;
 import lombok.extern.jbosslog.JBossLog;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -299,10 +296,8 @@ class ScimProviderResourceTest extends AbstractOrganizationTest {
 
     SharedSecretScimAuth resultAuth = (SharedSecretScimAuth) result.getAuth();
     String stored = resultAuth.getSharedSecret();
-    assertThat("server must not return the cleartext", stored,
-        not(is("super-secret-cleartext")));
-    assertThat("stored value must be a PHC argon2id hash", stored,
-        startsWith("$argon2id$"));
+    assertThat("server must not return the cleartext", stored, not(is("super-secret-cleartext")));
+    assertThat("stored value must be a PHC argon2id hash", stored, startsWith("$argon2id$"));
   }
 
   @Test
@@ -354,13 +349,10 @@ class ScimProviderResourceTest extends AbstractOrganizationTest {
             .readValue(response.getBody().asString(), OrganizationScimRepresentation.class);
     BasicAuthScimAuth resultAuth = (BasicAuthScimAuth) result.getAuth();
     assertThat(resultAuth.getUsername(), is("scim-admin"));
-    assertThat("username is never hashed", resultAuth.getUsername(),
-        not(startsWith("$argon2")));
-    assertThat("password is hashed before storage",
-        resultAuth.getPassword(),
-        startsWith("$argon2id$"));
-    assertThat(resultAuth.getPassword(),
-        not(is("plaintext-pass")));
+    assertThat("username is never hashed", resultAuth.getUsername(), not(startsWith("$argon2")));
+    assertThat(
+        "password is hashed before storage", resultAuth.getPassword(), startsWith("$argon2id$"));
+    assertThat(resultAuth.getPassword(), not(is("plaintext-pass")));
   }
 
   @Test
@@ -377,8 +369,7 @@ class ScimProviderResourceTest extends AbstractOrganizationTest {
     SharedSecretScimAuth secretAuth = new SharedSecretScimAuth();
     secretAuth.setSharedSecret("first-cleartext");
     rep.setAuth(secretAuth);
-    assertThat(
-        postRequest(rep, orgId, "scim").getStatusCode(), is(Status.CREATED.getStatusCode()));
+    assertThat(postRequest(rep, orgId, "scim").getStatusCode(), is(Status.CREATED.getStatusCode()));
 
     Response getResp = getRequest(orgId, "scim");
     String storedHash =
@@ -449,9 +440,7 @@ class ScimProviderResourceTest extends AbstractOrganizationTest {
 
     assertThat(secondHash, startsWith("$argon2id$"));
     assertThat(
-        "different cleartext should produce a different hash",
-        secondHash,
-        not(is(firstHash)));
+        "different cleartext should produce a different hash", secondHash, not(is(firstHash)));
   }
 
   @Test
@@ -467,16 +456,11 @@ class ScimProviderResourceTest extends AbstractOrganizationTest {
     rep.setAuth(new KeycloakScimAuth());
 
     // GET / POST / PUT / DELETE all return 404 when the feature is off.
+    assertThat(getRequest(orgId, "scim").getStatusCode(), is(Status.NOT_FOUND.getStatusCode()));
     assertThat(
-        getRequest(orgId, "scim").getStatusCode(), is(Status.NOT_FOUND.getStatusCode()));
+        postRequest(rep, orgId, "scim").getStatusCode(), is(Status.NOT_FOUND.getStatusCode()));
     assertThat(
-        postRequest(rep, orgId, "scim").getStatusCode(),
-        is(Status.NOT_FOUND.getStatusCode()));
-    assertThat(
-        putRequest(rep, orgId, "scim").getStatusCode(),
-        is(Status.NOT_FOUND.getStatusCode()));
-    assertThat(
-        deleteRequest(orgId, "scim").getStatusCode(),
-        is(Status.NOT_FOUND.getStatusCode()));
+        putRequest(rep, orgId, "scim").getStatusCode(), is(Status.NOT_FOUND.getStatusCode()));
+    assertThat(deleteRequest(orgId, "scim").getStatusCode(), is(Status.NOT_FOUND.getStatusCode()));
   }
 }

--- a/src/test/java/io/phasetwo/web/AbstractCypressOrganizationTest.java
+++ b/src/test/java/io/phasetwo/web/AbstractCypressOrganizationTest.java
@@ -113,11 +113,11 @@ public class AbstractCypressOrganizationTest {
             .withProviderClassesFrom("target/classes")
             .withProviderLibsFrom(getDeps())
             .withCustomCommand(
-                    "--spi-events-store-provider=" + MdcLoggerEventStoreProviderFactory.PROVIDER_ID)
+                "--spi-events-store-provider=" + MdcLoggerEventStoreProviderFactory.PROVIDER_ID)
             .withCustomCommand(
-                    "--spi-events-store-"
-                            + MdcLoggerEventStoreProviderFactory.PROVIDER_ID
-                            + "-use-jpa=true")
+                "--spi-events-store-"
+                    + MdcLoggerEventStoreProviderFactory.PROVIDER_ID
+                    + "-use-jpa=true")
             .withAccessToHost(true);
     if (isJacocoPresent()) {
       keycloakContainer =

--- a/src/test/java/io/phasetwo/web/CypressHomeIdpOrganizationTest.java
+++ b/src/test/java/io/phasetwo/web/CypressHomeIdpOrganizationTest.java
@@ -104,8 +104,8 @@ class CypressHomeIdpOrganizationTest extends AbstractCypressOrganizationTest {
             thirdIdentityProviderValidated -> {
               try {
                 setupKeycloakInstanceWithMultipleIdpsEnabledAtOrganization(); // sets up the
-                                                                              // keycloak with ~2
-                                                                              // IDP configs
+                // keycloak with ~2
+                // IDP configs
                 final var realm = findRealmByName("test-realm");
                 final var thirdClientRealm =
                     importRealm("/realms/external-idp.json", "third-external-idp");


### PR DESCRIPTION
Full reformat via `mvn fmt:format` (Spotify fmt-maven-plugin, Google style) so the build does not fail once fmt enforcement is introduced in https://github.com/p2-inc/keycloak-orgs/pull/467. No logic changes.

Tried this with IntelliJs auto-formatting from #467 , and it doesn't want to reformat these files anymore, so that' a win.