### PR TITLE
fix 401 on org admin endpoints under DPoP and master realm

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/ConditionalOrgAttributeMatchesClientAttribute.java
+++ b/src/main/java/io/phasetwo/service/auth/ConditionalOrgAttributeMatchesClientAttribute.java
@@ -1,6 +1,5 @@
 package io.phasetwo.service.auth;
 
-
 import io.phasetwo.service.model.OrganizationProvider;
 import java.util.Map;
 import lombok.extern.jbosslog.JBossLog;

--- a/src/main/java/io/phasetwo/service/importexport/KeycloakOrgsExportConverter.java
+++ b/src/main/java/io/phasetwo/service/importexport/KeycloakOrgsExportConverter.java
@@ -92,8 +92,8 @@ public final class KeycloakOrgsExportConverter {
     return role;
   }
 
-  private static OrganizationImportRepresentation convertOrganizationModelToOrganizationImportRepresentation(
-      OrganizationModel e) {
+  private static OrganizationImportRepresentation
+      convertOrganizationModelToOrganizationImportRepresentation(OrganizationModel e) {
     var o = new OrganizationImportRepresentation();
 
     o.setName(e.getName());

--- a/src/main/java/io/phasetwo/service/importexport/representation/OrganizationImportRepresentation.java
+++ b/src/main/java/io/phasetwo/service/importexport/representation/OrganizationImportRepresentation.java
@@ -7,10 +7,10 @@ import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import io.phasetwo.service.util.EmptyStringAsNullDeserializer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import io.phasetwo.service.util.EmptyStringAsNullDeserializer;
 import lombok.Data;
 
 @Data

--- a/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java
+++ b/src/main/java/io/phasetwo/service/model/jpa/JpaOrganizationProvider.java
@@ -107,9 +107,9 @@ public class JpaOrganizationProvider implements OrganizationProvider {
   public Stream<OrganizationModel> getOrganizationsStreamForDomain(
       RealmModel realm, String domain, boolean verified) {
     try {
-       domain = InternetDomainName.from(domain).toString();
-    } catch (IllegalArgumentException e){
-       return Stream.empty();
+      domain = InternetDomainName.from(domain).toString();
+    } catch (IllegalArgumentException e) {
+      return Stream.empty();
     }
 
     TypedQuery<DomainEntity> query =

--- a/src/main/java/io/phasetwo/service/resource/AbstractAdminResource.java
+++ b/src/main/java/io/phasetwo/service/resource/AbstractAdminResource.java
@@ -175,12 +175,30 @@ public abstract class AbstractAdminResource<T extends AdminAuth> {
       UriInfo uriInfo,
       ClientConnection connection,
       HttpHeaders headers) {
-    return new AppAuthManager.BearerTokenAuthenticator(session)
-        .setRealm(realm)
-        .setUriInfo(uriInfo)
-        .setTokenString(tokenString)
-        .setConnection(connection)
-        .setHeaders(headers)
-        .authenticate();
+    // For DPoP-bound tokens (`typ: DPoP`, `cnf.jkt` present), the Keycloak request
+    // pipeline for `/realms/<realm>/...` paths validates and consumes the DPoP
+    // proof's JTI before our resource handler runs. If we then call
+    // `BearerTokenAuthenticator.authenticate()`, it tries to re-validate the same
+    // proof inside `AuthenticationManager.verifyIdentityToken` via
+    // `DPoPUtil.withDPoPVerifier`, hits the replay-protection store ("DPoP proof
+    // has already been used"), and returns null. Stock admin endpoints under
+    // `/admin/...` don't hit this because they go through a different request
+    // pipeline that doesn't pre-validate the proof.
+    //
+    // Skip the DPoP wrapping by calling `verifyIdentityToken` directly with a
+    // no-op verifier consumer. Signature/issuer/audience/active checks still
+    // run; only DPoP's replay check is omitted (it ran upstream already).
+    return AuthenticationManager.verifyIdentityToken(
+        session,
+        realm,
+        uriInfo,
+        connection,
+        /* checkActive */ true,
+        /* checkTokenType */ true,
+        /* checkAudience */ null,
+        /* isCookie */ false,
+        tokenString,
+        headers,
+        /* verifierConsumer */ v -> {});
   }
 }

--- a/src/main/java/io/phasetwo/service/resource/Converters.java
+++ b/src/main/java/io/phasetwo/service/resource/Converters.java
@@ -2,13 +2,13 @@ package io.phasetwo.service.resource;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import io.phasetwo.service.scim.ComponentScimConfig;
-import io.phasetwo.service.util.Argon2idEncoder;
 import io.phasetwo.service.model.InvitationModel;
 import io.phasetwo.service.model.OrganizationModel;
 import io.phasetwo.service.model.OrganizationRoleModel;
 import io.phasetwo.service.model.jpa.entity.InvitationEntity;
 import io.phasetwo.service.representation.*;
+import io.phasetwo.service.scim.ComponentScimConfig;
+import io.phasetwo.service.util.Argon2idEncoder;
 import java.util.List;
 import java.util.Map;
 import org.keycloak.component.ComponentModel;

--- a/src/main/java/io/phasetwo/service/resource/OrganizationAdminAuth.java
+++ b/src/main/java/io/phasetwo/service/resource/OrganizationAdminAuth.java
@@ -36,20 +36,19 @@ public class OrganizationAdminAuth extends AdminAuth {
   }
 
   /**
-   * Override Keycloak's default {@code AdminAuth.hasAppRole(app, role)}, which returns
-   * {@code user.hasRole(role) && client.hasScope(role)}. The {@code client.hasScope}
-   * predicate is meaningful for OIDC clients calling admin endpoints with their own
-   * access token (it ensures the OP granted the role's scope to the calling client).
-   * It is not meaningful here, because {@link AbstractAdminResource} synthesizes the
-   * {@code client} field as the target realm's master-admin-client — its scope is an
-   * accident of which client we picked, not part of the actual authorization
-   * decision.
+   * Override Keycloak's default {@code AdminAuth.hasAppRole(app, role)}, which returns {@code
+   * user.hasRole(role) && client.hasScope(role)}. The {@code client.hasScope} predicate is
+   * meaningful for OIDC clients calling admin endpoints with their own access token (it ensures the
+   * OP granted the role's scope to the calling client). It is not meaningful here, because {@link
+   * AbstractAdminResource} synthesizes the {@code client} field as the target realm's
+   * master-admin-client — its scope is an accident of which client we picked, not part of the
+   * actual authorization decision.
    *
-   * In particular, master's master-admin-client ({@code master-realm}) and other
-   * realms' master-admin-clients ({@code <realm>-realm}) can have divergent scope
-   * configurations, causing realm-admin checks to succeed on non-master realms and
-   * 401 on master itself. Restricting the check to the model-side role mapping
-   * ({@code user.hasRole}) makes authorization uniform across realms.
+   * <p>In particular, master's master-admin-client ({@code master-realm}) and other realms'
+   * master-admin-clients ({@code <realm>-realm}) can have divergent scope configurations, causing
+   * realm-admin checks to succeed on non-master realms and 401 on master itself. Restricting the
+   * check to the model-side role mapping ({@code user.hasRole}) makes authorization uniform across
+   * realms.
    */
   @Override
   public boolean hasAppRole(ClientModel app, String role) {

--- a/src/main/java/io/phasetwo/service/resource/OrganizationAdminAuth.java
+++ b/src/main/java/io/phasetwo/service/resource/OrganizationAdminAuth.java
@@ -15,6 +15,7 @@ import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.jpa.entities.UserEntity;
 import org.keycloak.representations.AccessToken;
@@ -32,6 +33,29 @@ public class OrganizationAdminAuth extends AdminAuth {
       RealmModel realm, AccessToken token, UserModel user, ClientModel client) {
     super(realm, token, user, client);
     log.debugf("Realm passed to ctr is %s", realm.getName());
+  }
+
+  /**
+   * Override Keycloak's default {@code AdminAuth.hasAppRole(app, role)}, which returns
+   * {@code user.hasRole(role) && client.hasScope(role)}. The {@code client.hasScope}
+   * predicate is meaningful for OIDC clients calling admin endpoints with their own
+   * access token (it ensures the OP granted the role's scope to the calling client).
+   * It is not meaningful here, because {@link AbstractAdminResource} synthesizes the
+   * {@code client} field as the target realm's master-admin-client — its scope is an
+   * accident of which client we picked, not part of the actual authorization
+   * decision.
+   *
+   * In particular, master's master-admin-client ({@code master-realm}) and other
+   * realms' master-admin-clients ({@code <realm>-realm}) can have divergent scope
+   * configurations, causing realm-admin checks to succeed on non-master realms and
+   * 401 on master itself. Restricting the check to the model-side role mapping
+   * ({@code user.hasRole}) makes authorization uniform across realms.
+   */
+  @Override
+  public boolean hasAppRole(ClientModel app, String role) {
+    if (app == null) return false;
+    RoleModel roleModel = app.getRole(role);
+    return roleModel != null && getUser().hasRole(roleModel);
   }
 
   // create-organization

--- a/src/main/java/io/phasetwo/service/resource/OrganizationsResource.java
+++ b/src/main/java/io/phasetwo/service/resource/OrganizationsResource.java
@@ -271,8 +271,8 @@ public class OrganizationsResource extends OrganizationAdminResource {
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   public Response addOrganizationsConfig(@Valid OrganizationsConfig body) {
-    log.debugf("Create org config for realm %s", realm.getName());
-    if (!auth.hasManageRealm()) {
+    log.debugf("Update org config for realm %s", realm.getName());
+    if (!permissions.realm().canManageRealm()) {
       throw new NotAuthorizedException("Insufficient permission to update organization config.");
     }
     resetIdentityProviders(body.isSharedIdps());
@@ -308,9 +308,9 @@ public class OrganizationsResource extends OrganizationAdminResource {
   @Path("config")
   @Produces(MediaType.APPLICATION_JSON)
   public Response getOrganizationConfig() {
-    log.debugf("Create org config for realm %s", realm.getName());
-    if (!auth.hasManageRealm()) {
-      throw new NotAuthorizedException("Insufficient permission to update organization config.");
+    log.debugf("Get org config for realm %s", realm.getName());
+    if (!permissions.realm().canManageRealm()) {
+      throw new NotAuthorizedException("Insufficient permission to view organization config.");
     }
 
     var representation = new OrganizationsConfig();

--- a/src/main/java/io/phasetwo/service/resource/ScimProviderResource.java
+++ b/src/main/java/io/phasetwo/service/resource/ScimProviderResource.java
@@ -29,9 +29,9 @@ public class ScimProviderResource extends OrganizationAdminResource {
   }
 
   /**
-   * If the realm-level SCIM feature flag is disabled, the entire resource pretends
-   * not to exist (404). The flag defaults to false; flip it on via the
-   * Organization Settings UI or {@code /realms/{realm}/orgs/config}.
+   * If the realm-level SCIM feature flag is disabled, the entire resource pretends not to exist
+   * (404). The flag defaults to false; flip it on via the Organization Settings UI or {@code
+   * /realms/{realm}/orgs/config}.
    */
   private void requireScimEnabled() {
     if (!session.getContext().getRealm().getAttribute(ORG_CONFIG_SCIM_ENABLED_KEY, false)) {
@@ -78,8 +78,7 @@ public class ScimProviderResource extends OrganizationAdminResource {
           .build();
     }
 
-    ComponentScimConfig newConfig =
-        convertRepresentationToScimConfig(rep);
+    ComponentScimConfig newConfig = convertRepresentationToScimConfig(rep);
     ComponentScimConfig created =
         configProvider.createConfiguration(organization.getId(), newConfig);
 
@@ -112,8 +111,7 @@ public class ScimProviderResource extends OrganizationAdminResource {
       throw new NotFoundException("No SCIM configuration found for organization");
     }
 
-    ComponentScimConfig updateConfig =
-        convertRepresentationToScimConfig(rep);
+    ComponentScimConfig updateConfig = convertRepresentationToScimConfig(rep);
     ComponentScimConfig updated =
         configProvider.updateConfiguration(organization.getId(), updateConfig);
 

--- a/src/main/java/io/phasetwo/service/scim/PhasetwoOrganizationScimServerProvider.java
+++ b/src/main/java/io/phasetwo/service/scim/PhasetwoOrganizationScimServerProvider.java
@@ -65,8 +65,7 @@ public class PhasetwoOrganizationScimServerProvider implements OrganizationScimS
                 String.format(
                     "realms/%s/scim/v2/organizations/%s/", realm.getName(), organization.getId()));
 
-    ScimConfigurationProvider configProvider =
-        session.getProvider(ScimConfigurationProvider.class);
+    ScimConfigurationProvider configProvider = session.getProvider(ScimConfigurationProvider.class);
     ComponentScimConfig config = configProvider.getConfiguration(organizationId);
     if (config == null) {
       throw new NotFoundException(organizationId + " has no SCIM configuration");

--- a/src/main/java/io/phasetwo/service/scim/federation/OrgScimUserStorageProvider.java
+++ b/src/main/java/io/phasetwo/service/scim/federation/OrgScimUserStorageProvider.java
@@ -5,20 +5,15 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.storage.UserStorageProvider;
 
 /**
- * Empty UserStorageProvider. Its existence makes
- * {@link OrgScimUserStorageProviderFactory} a valid registered
- * {@link org.keycloak.storage.UserStorageProviderFactory}, which is
- * what Keycloak's {@code realm.addComponentModel} requires to accept
- * the {@code ComponentModel}s used for per-organization SCIM
- * configuration storage.
+ * Empty UserStorageProvider. Its existence makes {@link OrgScimUserStorageProviderFactory} a valid
+ * registered {@link org.keycloak.storage.UserStorageProviderFactory}, which is what Keycloak's
+ * {@code realm.addComponentModel} requires to accept the {@code ComponentModel}s used for
+ * per-organization SCIM configuration storage.
  *
- * <p>This provider itself does nothing at runtime; the SCIM config
- * data is read/written by
- * {@link io.phasetwo.service.scim.spi.DefaultScimConfigurationProvider}
- * directly against the realm's components container. Per-organization
- * SCIM configuration is normally managed through the
- * {@code /{realm}/orgs/{orgId}/scim} REST endpoint and the Admin UI
- * tab exposed by keycloak-themes.
+ * <p>This provider itself does nothing at runtime; the SCIM config data is read/written by {@link
+ * io.phasetwo.service.scim.spi.DefaultScimConfigurationProvider} directly against the realm's
+ * components container. Per-organization SCIM configuration is normally managed through the {@code
+ * /{realm}/orgs/{orgId}/scim} REST endpoint and the Admin UI tab exposed by keycloak-themes.
  */
 public class OrgScimUserStorageProvider implements UserStorageProvider {
 

--- a/src/main/java/io/phasetwo/service/scim/federation/OrgScimUserStorageProviderFactory.java
+++ b/src/main/java/io/phasetwo/service/scim/federation/OrgScimUserStorageProviderFactory.java
@@ -14,27 +14,23 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.storage.UserStorageProviderFactory;
 
 /**
- * Registers an "Organization SCIM" User Federation provider. Its sole
- * purpose is to make Keycloak's ComponentModel infrastructure accept
- * SCIM-config persistence: the SCIM-tab REST endpoint creates a
- * {@code ComponentModel} with
- * {@code providerType=org.keycloak.storage.UserStorageProvider} and
- * {@code providerId="Organization SCIM"}, and Keycloak validates that
- * combo against a registered factory at add/update time.
+ * Registers an "Organization SCIM" User Federation provider. Its sole purpose is to make Keycloak's
+ * ComponentModel infrastructure accept SCIM-config persistence: the SCIM-tab REST endpoint creates
+ * a {@code ComponentModel} with {@code providerType=org.keycloak.storage.UserStorageProvider} and
+ * {@code providerId="Organization SCIM"}, and Keycloak validates that combo against a registered
+ * factory at add/update time.
  *
- * <p>Side effect: the entry appears in the Keycloak Admin Console's
- * User Federation page. That's accepted as a cosmetic compromise — the
- * canonical UI for managing SCIM configs is the per-org SCIM tab.
+ * <p>Side effect: the entry appears in the Keycloak Admin Console's User Federation page. That's
+ * accepted as a cosmetic compromise — the canonical UI for managing SCIM configs is the per-org
+ * SCIM tab.
  *
- * <p>An earlier iteration tried to gate this factory behind
- * {@code EnvironmentDependentProviderFactory#isSupported} so it could
- * be hidden from the User Federation list by default, but that broke
- * storage entirely (no registered factory means
- * {@code realm.addComponentModel} throws "No such provider"). Hiding
- * just the UI listing without breaking storage would require turning
- * {@code ScimConfigurationProviderFactory} into a full
- * {@link org.keycloak.component.ComponentFactory} and switching the
- * storage providerType to our SPI's FQCN.
+ * <p>An earlier iteration tried to gate this factory behind {@code
+ * EnvironmentDependentProviderFactory#isSupported} so it could be hidden from the User Federation
+ * list by default, but that broke storage entirely (no registered factory means {@code
+ * realm.addComponentModel} throws "No such provider"). Hiding just the UI listing without breaking
+ * storage would require turning {@code ScimConfigurationProviderFactory} into a full {@link
+ * org.keycloak.component.ComponentFactory} and switching the storage providerType to our SPI's
+ * FQCN.
  */
 @SuppressWarnings("rawtypes")
 @JBossLog

--- a/src/main/java/io/phasetwo/service/scim/spi/DefaultScimConfigurationProvider.java
+++ b/src/main/java/io/phasetwo/service/scim/spi/DefaultScimConfigurationProvider.java
@@ -5,9 +5,7 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 
-/**
- * Default implementation of ScimConfigurationProvider backed by Keycloak ComponentModel.
- */
+/** Default implementation of ScimConfigurationProvider backed by Keycloak ComponentModel. */
 public class DefaultScimConfigurationProvider implements ScimConfigurationProvider {
 
   private final KeycloakSession session;
@@ -91,14 +89,12 @@ public class DefaultScimConfigurationProvider implements ScimConfigurationProvid
   private void copyConfigToModel(ComponentModel target, ComponentScimConfig source) {
     if (source.getAuthenticationMode() != null) {
       target.put(
-          ComponentScimConfig.SCIM_AUTHENTICATION_MODE,
-          source.getAuthenticationMode().name());
+          ComponentScimConfig.SCIM_AUTHENTICATION_MODE, source.getAuthenticationMode().name());
     }
     setOrRemove(target, ComponentScimConfig.SCIM_EXTERNAL_ISSUER, source.getExternalIssuer());
     setOrRemove(target, ComponentScimConfig.SCIM_EXTERNAL_AUDIENCE, source.getExternalAudience());
     setOrRemove(target, ComponentScimConfig.SCIM_EXTERNAL_JWKS_URI, source.getExternalJwksUri());
-    setOrRemove(
-        target, ComponentScimConfig.SCIM_EXTERNAL_SHARED_SECRET, source.getSharedSecret());
+    setOrRemove(target, ComponentScimConfig.SCIM_EXTERNAL_SHARED_SECRET, source.getSharedSecret());
     setOrRemove(
         target, ComponentScimConfig.SCIM_BASIC_AUTH_USERNAME, source.getBasicAuthUsername());
     setOrRemove(

--- a/src/main/java/io/phasetwo/service/scim/spi/ScimConfigurationProvider.java
+++ b/src/main/java/io/phasetwo/service/scim/spi/ScimConfigurationProvider.java
@@ -4,8 +4,8 @@ import io.phasetwo.service.scim.ComponentScimConfig;
 import org.keycloak.provider.Provider;
 
 /**
- * SPI for managing per-organization SCIM configurations.
- * Abstracts away the underlying persistence mechanism.
+ * SPI for managing per-organization SCIM configurations. Abstracts away the underlying persistence
+ * mechanism.
  */
 public interface ScimConfigurationProvider extends Provider {
 

--- a/src/main/java/io/phasetwo/service/util/Argon2idEncoder.java
+++ b/src/main/java/io/phasetwo/service/util/Argon2idEncoder.java
@@ -29,16 +29,14 @@ public final class Argon2idEncoder {
 
   private Argon2idEncoder() {}
 
-  /**
-   * Returns true if the given value already looks like a PHC-formatted argon2 string.
-   */
+  /** Returns true if the given value already looks like a PHC-formatted argon2 string. */
   public static boolean isAlreadyHashed(String value) {
     return value != null && value.startsWith(PHC_PREFIX);
   }
 
   /**
-   * Encodes the given cleartext value into a PHC-formatted argon2id hash.
-   * Returns the input unchanged if it already looks like a PHC string.
+   * Encodes the given cleartext value into a PHC-formatted argon2id hash. Returns the input
+   * unchanged if it already looks like a PHC string.
    */
   public static String encode(String cleartext) {
     if (cleartext == null || cleartext.isEmpty() || isAlreadyHashed(cleartext)) {
@@ -65,7 +63,10 @@ public final class Argon2idEncoder {
 
     return String.format(
         "$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
-        VERSION, MEMORY_KB, ITERATIONS, PARALLELISM,
+        VERSION,
+        MEMORY_KB,
+        ITERATIONS,
+        PARALLELISM,
         ENCODER.encodeToString(salt),
         ENCODER.encodeToString(hash));
   }

--- a/src/main/java/io/phasetwo/service/util/EmptyStringAsNullDeserializer.java
+++ b/src/main/java/io/phasetwo/service/util/EmptyStringAsNullDeserializer.java
@@ -4,17 +4,16 @@ import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-
 import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Predicate;
 
 public class EmptyStringAsNullDeserializer extends JsonDeserializer<String> {
-    @Override
-    public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
-        return Optional
-                .ofNullable(p.getValueAsString())
-                .filter(Predicate.not(String::isEmpty))
-                .orElse(null);
-    }
+  @Override
+  public String deserialize(JsonParser p, DeserializationContext ctxt)
+      throws IOException, JacksonException {
+    return Optional.ofNullable(p.getValueAsString())
+        .filter(Predicate.not(String::isEmpty))
+        .orElse(null);
+  }
 }

--- a/src/test/java/io/phasetwo/service/AbstractOrganizationTest.java
+++ b/src/test/java/io/phasetwo/service/AbstractOrganizationTest.java
@@ -23,7 +23,6 @@ import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.phasetwo.client.openapi.model.OrganizationRepresentation;
 import io.phasetwo.client.openapi.model.OrganizationRoleRepresentation;
 import io.phasetwo.keycloak.events.MdcLoggerEventStoreProviderFactory;
-import io.phasetwo.service.KeycloakOrgsAdminAPI;
 import io.phasetwo.service.importexport.representation.InvitationRepresentation;
 import io.phasetwo.service.importexport.representation.KeycloakOrgsRepresentation;
 import io.phasetwo.service.importexport.representation.UserRolesRepresentation;
@@ -101,11 +100,11 @@ public abstract class AbstractOrganizationTest {
           .withExposedPorts(8787, 9000, 8080)
           .withProviderLibsFrom(getDeps())
           .withCustomCommand(
-                  "--spi-events-store-provider=" + MdcLoggerEventStoreProviderFactory.PROVIDER_ID)
+              "--spi-events-store-provider=" + MdcLoggerEventStoreProviderFactory.PROVIDER_ID)
           .withCustomCommand(
-                  "--spi-events-store-"
-                          + MdcLoggerEventStoreProviderFactory.PROVIDER_ID
-                          + "-use-jpa=true")
+              "--spi-events-store-"
+                  + MdcLoggerEventStoreProviderFactory.PROVIDER_ID
+                  + "-use-jpa=true")
           .withEnv(
               "JAVA_OPTS",
               "-agentlib:jdwp=transport=dt_socket,address=*:8787,server=y,suspend=n -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m ")

--- a/src/test/java/io/phasetwo/service/globalconfig/ScimFeatureFlagTest.java
+++ b/src/test/java/io/phasetwo/service/globalconfig/ScimFeatureFlagTest.java
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies the realm-level SCIM feature flag exposed at
- * {@code PUT/GET /realms/{realm}/orgs/config}.
+ * Verifies the realm-level SCIM feature flag exposed at {@code PUT/GET
+ * /realms/{realm}/orgs/config}.
  */
 @JBossLog
 public class ScimFeatureFlagTest extends AbstractOrganizationTest {

--- a/src/test/java/io/phasetwo/service/importexport/OrganizationImportWithDatabaseAccessTest.java
+++ b/src/test/java/io/phasetwo/service/importexport/OrganizationImportWithDatabaseAccessTest.java
@@ -10,13 +10,11 @@ import static org.hamcrest.Matchers.is;
 import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.phasetwo.service.importexport.representation.KeycloakOrgsRepresentation;
 import jakarta.ws.rs.core.Response;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -32,136 +30,136 @@ import org.testcontainers.containers.PostgreSQLContainer;
  * environment, along with database query validations. This test class uses a PostgreSQL container
  * and Keycloak container as part of its test setup.
  *
- *  The tests primarily focus on:
- * - Importing a realm into Keycloak.
- * - Importing organizations into the realm.
- * - Validating the database to ensure the imported organizations are correctly added.
+ * <p>The tests primarily focus on: - Importing a realm into Keycloak. - Importing organizations
+ * into the realm. - Validating the database to ensure the imported organizations are correctly
+ * added.
  *
- * With these validations, the test ensures that we store what we expect in the database, and there's no hidden
- * error in the API-level conversions
- *
+ * <p>With these validations, the test ensures that we store what we expect in the database, and
+ * there's no hidden error in the API-level conversions
  */
 @DisplayName("Tests for the Organization import endpoints with database-query verifications")
 public class OrganizationImportWithDatabaseAccessTest {
 
-    private static Network network = Network.newNetwork();
+  private static Network network = Network.newNetwork();
 
-    private static final PostgreSQLContainer<?> postgres =
-            new PostgreSQLContainer<>("postgres:16")
-                    .withNetwork(network)
-                    .withNetworkAliases("postgres")
-                    .withDatabaseName("keycloak")
-                    .withUsername("keycloak")
-                    .withPassword("password");
+  private static final PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>("postgres:16")
+          .withNetwork(network)
+          .withNetworkAliases("postgres")
+          .withDatabaseName("keycloak")
+          .withUsername("keycloak")
+          .withPassword("password");
 
-    private static KeycloakContainer keycloakContainer =
-            new KeycloakContainer(KEYCLOAK_IMAGE)
-                    .withNetwork(network)
-                    .withContextPath("/auth")
-                    .withProviderClassesFrom("target/classes")
-                    .withProviderLibsFrom(getDeps())
-                    .withEnv("KC_DB", "postgres")
-                    .withEnv("KC_DB_URL", "jdbc:postgresql://postgres:5432/keycloak?loggerLevel=OFF")
-                    .withEnv("KC_DB_USERNAME", postgres.getUsername())
-                    .withEnv("KC_DB_PASSWORD", postgres.getPassword())
-                    .withAccessToHost(true);
-    private static Keycloak keycloak;
+  private static KeycloakContainer keycloakContainer =
+      new KeycloakContainer(KEYCLOAK_IMAGE)
+          .withNetwork(network)
+          .withContextPath("/auth")
+          .withProviderClassesFrom("target/classes")
+          .withProviderLibsFrom(getDeps())
+          .withEnv("KC_DB", "postgres")
+          .withEnv("KC_DB_URL", "jdbc:postgresql://postgres:5432/keycloak?loggerLevel=OFF")
+          .withEnv("KC_DB_USERNAME", postgres.getUsername())
+          .withEnv("KC_DB_PASSWORD", postgres.getPassword())
+          .withAccessToHost(true);
+  private static Keycloak keycloak;
 
-    @BeforeAll
-    public static void setUp() {
-        postgres.start();
-        keycloakContainer.start();
+  @BeforeAll
+  public static void setUp() {
+    postgres.start();
+    keycloakContainer.start();
 
-        keycloak =
-                Keycloak.getInstance(
-                        keycloakContainer.getAuthServerUrl(),
-                        "master",
-                        keycloakContainer.getAdminUsername(),
-                        keycloakContainer.getAdminPassword(),
-                        "admin-cli");
+    keycloak =
+        Keycloak.getInstance(
+            keycloakContainer.getAuthServerUrl(),
+            "master",
+            keycloakContainer.getAdminUsername(),
+            keycloakContainer.getAdminPassword(),
+            "admin-cli");
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    if (keycloakContainer != null) {
+      keycloakContainer.stop();
     }
-
-    @AfterAll
-    public static void tearDown() {
-        if (keycloakContainer != null) {
-            keycloakContainer.stop();
-        }
-        if (postgres != null) {
-            postgres.stop();
-        }
-        if (network != null) {
-            network.close();
-        }
+    if (postgres != null) {
+      postgres.stop();
     }
-
-    @Test
-    @DisplayName("Import organization with empty string as domain and verify that the empty domain is not stored in the database")
-    void testOrganizationWithEmptyDomainImportAndVerifyInDatabase() throws SQLException {
-        String realmName = "test-realm";
-
-        // 1. Import Realm
-        RealmRepresentation testRealm =
-                loadJson(
-                        OrganizationImportWithDatabaseAccessTest.class.getResourceAsStream(
-                                "/orgs/keycloak-realm-with-identity-provider.json"),
-                        RealmRepresentation.class);
-        testRealm.setRealm(realmName);
-
-        var realmResponse =
-                given()
-                        .baseUri(keycloakContainer.getAuthServerUrl())
-                        .basePath("admin/realms/")
-                        .contentType("application/json")
-                        .auth()
-                        .oauth2(keycloak.tokenManager().getAccessTokenString())
-                        .and()
-                        .body(testRealm)
-                        .when()
-                        .post()
-                        .then()
-                        .extract()
-                        .response();
-        assertThat(realmResponse.getStatusCode(), CoreMatchers.is(Response.Status.CREATED.getStatusCode()));
-
-        // 2. Import Organization
-        KeycloakOrgsRepresentation orgsRepresentation =
-                loadJson(
-                        OrganizationImportWithDatabaseAccessTest.class.getResourceAsStream(
-                                "/orgs/org-import-test.json"),
-                        KeycloakOrgsRepresentation.class);
-
-        var orgsResponse =
-                given()
-                        .baseUri(keycloakContainer.getAuthServerUrl())
-                        .basePath("realms/" + realmName + "/orgs")
-                        .contentType("application/json")
-                        .auth()
-                        .oauth2(keycloak.tokenManager().getAccessTokenString())
-                        .queryParam("skipMissingMember", false)
-                        .queryParam("skipMissingIdp", false)
-                        .when()
-                        .and()
-                        .body(orgsRepresentation)
-                        .when()
-                        .post("import")
-                        .then()
-                        .extract()
-                        .response();
-        assertThat(orgsResponse.getStatusCode(), CoreMatchers.is(Response.Status.OK.getStatusCode()));
-
-        // 3. Verify in Database
-        try (Connection conn =
-                     DriverManager.getConnection(
-                             postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
-             Statement stmt = conn.createStatement()) {
-
-            ResultSet rs = stmt.executeQuery("SELECT count(*) FROM ORGANIZATION WHERE NAME = 'test1'");
-            rs.next();
-            assertThat("Organization test1 should exist in database", rs.getInt(1), is(1));
-
-            rs = stmt.executeQuery("SELECT count(*) FROM ORGANIZATION_DOMAIN WHERE domain = ''");
-            rs.next();
-            assertThat("There should be no empty string domains in the database", rs.getInt(1), is(0));
-        }
+    if (network != null) {
+      network.close();
     }
+  }
+
+  @Test
+  @DisplayName(
+      "Import organization with empty string as domain and verify that the empty domain is not stored in the database")
+  void testOrganizationWithEmptyDomainImportAndVerifyInDatabase() throws SQLException {
+    String realmName = "test-realm";
+
+    // 1. Import Realm
+    RealmRepresentation testRealm =
+        loadJson(
+            OrganizationImportWithDatabaseAccessTest.class.getResourceAsStream(
+                "/orgs/keycloak-realm-with-identity-provider.json"),
+            RealmRepresentation.class);
+    testRealm.setRealm(realmName);
+
+    var realmResponse =
+        given()
+            .baseUri(keycloakContainer.getAuthServerUrl())
+            .basePath("admin/realms/")
+            .contentType("application/json")
+            .auth()
+            .oauth2(keycloak.tokenManager().getAccessTokenString())
+            .and()
+            .body(testRealm)
+            .when()
+            .post()
+            .then()
+            .extract()
+            .response();
+    assertThat(
+        realmResponse.getStatusCode(), CoreMatchers.is(Response.Status.CREATED.getStatusCode()));
+
+    // 2. Import Organization
+    KeycloakOrgsRepresentation orgsRepresentation =
+        loadJson(
+            OrganizationImportWithDatabaseAccessTest.class.getResourceAsStream(
+                "/orgs/org-import-test.json"),
+            KeycloakOrgsRepresentation.class);
+
+    var orgsResponse =
+        given()
+            .baseUri(keycloakContainer.getAuthServerUrl())
+            .basePath("realms/" + realmName + "/orgs")
+            .contentType("application/json")
+            .auth()
+            .oauth2(keycloak.tokenManager().getAccessTokenString())
+            .queryParam("skipMissingMember", false)
+            .queryParam("skipMissingIdp", false)
+            .when()
+            .and()
+            .body(orgsRepresentation)
+            .when()
+            .post("import")
+            .then()
+            .extract()
+            .response();
+    assertThat(orgsResponse.getStatusCode(), CoreMatchers.is(Response.Status.OK.getStatusCode()));
+
+    // 3. Verify in Database
+    try (Connection conn =
+            DriverManager.getConnection(
+                postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+        Statement stmt = conn.createStatement()) {
+
+      ResultSet rs = stmt.executeQuery("SELECT count(*) FROM ORGANIZATION WHERE NAME = 'test1'");
+      rs.next();
+      assertThat("Organization test1 should exist in database", rs.getInt(1), is(1));
+
+      rs = stmt.executeQuery("SELECT count(*) FROM ORGANIZATION_DOMAIN WHERE domain = ''");
+      rs.next();
+      assertThat("There should be no empty string domains in the database", rs.getInt(1), is(0));
+    }
+  }
 }

--- a/src/test/java/io/phasetwo/service/resource/AbstractDbCompatibilityTest.java
+++ b/src/test/java/io/phasetwo/service/resource/AbstractDbCompatibilityTest.java
@@ -29,12 +29,12 @@ import org.testcontainers.images.PullPolicy;
 import org.testcontainers.utility.MountableFile;
 
 /**
- * Base class for database-compatibility smoke tests. To add support for a new database, extend
- * this class, annotate it with {@code @TestInstance(Lifecycle.PER_CLASS)}, and implement the three
+ * Base class for database-compatibility smoke tests. To add support for a new database, extend this
+ * class, annotate it with {@code @TestInstance(Lifecycle.PER_CLASS)}, and implement the three
  * abstract methods. The inherited {@code @Test} will run automatically.
  *
- * <p>Tests only execute when {@code -Dinclude.integration=true} is set (activated by the
- * {@code integration-tests} Maven profile).
+ * <p>Tests only execute when {@code -Dinclude.integration=true} is set (activated by the {@code
+ * integration-tests} Maven profile).
  */
 @JBossLog
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/src/test/java/io/phasetwo/service/resource/OrganizationResourceTest.java
+++ b/src/test/java/io/phasetwo/service/resource/OrganizationResourceTest.java
@@ -2561,7 +2561,8 @@ class OrganizationResourceTest extends AbstractOrganizationTest {
       // Get the list of roles to verify the delete-organization role exists by default
       Response response = getRequest(orgId);
       assertThat(response.getStatusCode(), is(Status.OK.getStatusCode()));
-      final var orgRep = objectMapper().readValue(response.getBody().asString(), OrganizationRepresentation.class);
+      final var orgRep =
+          objectMapper().readValue(response.getBody().asString(), OrganizationRepresentation.class);
       final var currentDomainList = orgRep.getDomains();
       final var updatedDomainList = new ArrayList<>(currentDomainList);
       updatedDomainList.add("");
@@ -2572,10 +2573,14 @@ class OrganizationResourceTest extends AbstractOrganizationTest {
 
       Response responseAfterModification = getRequest(orgId);
       assertThat(responseAfterModification.getStatusCode(), is(Status.OK.getStatusCode()));
-      final var orgRepAfterModification = objectMapper().readValue(responseAfterModification.getBody().asString(), OrganizationRepresentation.class);
+      final var orgRepAfterModification =
+          objectMapper()
+              .readValue(
+                  responseAfterModification.getBody().asString(), OrganizationRepresentation.class);
       final var expectedDomains = new HashSet<>(currentDomainList);
       expectedDomains.add("vnagy.eu");
-      assertThat(orgRepAfterModification.getDomains(), containsInAnyOrder(expectedDomains.toArray()));
+      assertThat(
+          orgRepAfterModification.getDomains(), containsInAnyOrder(expectedDomains.toArray()));
     } finally {
       // Clean up
       deleteOrganization(orgId);
@@ -2593,7 +2598,8 @@ class OrganizationResourceTest extends AbstractOrganizationTest {
       // Get the list of roles to verify the delete-organization role exists by default
       Response response = getRequest(orgId);
       assertThat(response.getStatusCode(), is(Status.OK.getStatusCode()));
-      final var orgRep = objectMapper().readValue(response.getBody().asString(), OrganizationRepresentation.class);
+      final var orgRep =
+          objectMapper().readValue(response.getBody().asString(), OrganizationRepresentation.class);
       final var currentDomainList = orgRep.getDomains();
       final var updatedDomainList = new ArrayList<>(currentDomainList);
       updatedDomainList.add("");
@@ -2605,10 +2611,14 @@ class OrganizationResourceTest extends AbstractOrganizationTest {
 
       Response responseAfterModification = getRequest(orgId);
       assertThat(responseAfterModification.getStatusCode(), is(Status.OK.getStatusCode()));
-      final var orgRepAfterModification = objectMapper().readValue(responseAfterModification.getBody().asString(), OrganizationRepresentation.class);
+      final var orgRepAfterModification =
+          objectMapper()
+              .readValue(
+                  responseAfterModification.getBody().asString(), OrganizationRepresentation.class);
       final var expectedDomains = new HashSet<>(currentDomainList);
       expectedDomains.add("vnagy.eu");
-      assertThat(orgRepAfterModification.getDomains(), containsInAnyOrder(expectedDomains.toArray()));
+      assertThat(
+          orgRepAfterModification.getDomains(), containsInAnyOrder(expectedDomains.toArray()));
     } finally {
       // Clean up
       deleteOrganization(orgId);

--- a/src/test/java/io/phasetwo/service/resource/ScimProviderResourceTest.java
+++ b/src/test/java/io/phasetwo/service/resource/ScimProviderResourceTest.java
@@ -5,17 +5,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.phasetwo.client.openapi.model.OrganizationRepresentation;
 import io.phasetwo.service.AbstractOrganizationTest;
 import io.phasetwo.service.representation.*;
 import io.restassured.response.Response;
 import jakarta.ws.rs.core.Response.Status;
 import java.io.IOException;
-import java.util.List;
 import lombok.extern.jbosslog.JBossLog;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -299,10 +296,8 @@ class ScimProviderResourceTest extends AbstractOrganizationTest {
 
     SharedSecretScimAuth resultAuth = (SharedSecretScimAuth) result.getAuth();
     String stored = resultAuth.getSharedSecret();
-    assertThat("server must not return the cleartext", stored,
-        not(is("super-secret-cleartext")));
-    assertThat("stored value must be a PHC argon2id hash", stored,
-        startsWith("$argon2id$"));
+    assertThat("server must not return the cleartext", stored, not(is("super-secret-cleartext")));
+    assertThat("stored value must be a PHC argon2id hash", stored, startsWith("$argon2id$"));
   }
 
   @Test
@@ -354,13 +349,10 @@ class ScimProviderResourceTest extends AbstractOrganizationTest {
             .readValue(response.getBody().asString(), OrganizationScimRepresentation.class);
     BasicAuthScimAuth resultAuth = (BasicAuthScimAuth) result.getAuth();
     assertThat(resultAuth.getUsername(), is("scim-admin"));
-    assertThat("username is never hashed", resultAuth.getUsername(),
-        not(startsWith("$argon2")));
-    assertThat("password is hashed before storage",
-        resultAuth.getPassword(),
-        startsWith("$argon2id$"));
-    assertThat(resultAuth.getPassword(),
-        not(is("plaintext-pass")));
+    assertThat("username is never hashed", resultAuth.getUsername(), not(startsWith("$argon2")));
+    assertThat(
+        "password is hashed before storage", resultAuth.getPassword(), startsWith("$argon2id$"));
+    assertThat(resultAuth.getPassword(), not(is("plaintext-pass")));
   }
 
   @Test
@@ -377,8 +369,7 @@ class ScimProviderResourceTest extends AbstractOrganizationTest {
     SharedSecretScimAuth secretAuth = new SharedSecretScimAuth();
     secretAuth.setSharedSecret("first-cleartext");
     rep.setAuth(secretAuth);
-    assertThat(
-        postRequest(rep, orgId, "scim").getStatusCode(), is(Status.CREATED.getStatusCode()));
+    assertThat(postRequest(rep, orgId, "scim").getStatusCode(), is(Status.CREATED.getStatusCode()));
 
     Response getResp = getRequest(orgId, "scim");
     String storedHash =
@@ -449,9 +440,7 @@ class ScimProviderResourceTest extends AbstractOrganizationTest {
 
     assertThat(secondHash, startsWith("$argon2id$"));
     assertThat(
-        "different cleartext should produce a different hash",
-        secondHash,
-        not(is(firstHash)));
+        "different cleartext should produce a different hash", secondHash, not(is(firstHash)));
   }
 
   @Test
@@ -467,16 +456,11 @@ class ScimProviderResourceTest extends AbstractOrganizationTest {
     rep.setAuth(new KeycloakScimAuth());
 
     // GET / POST / PUT / DELETE all return 404 when the feature is off.
+    assertThat(getRequest(orgId, "scim").getStatusCode(), is(Status.NOT_FOUND.getStatusCode()));
     assertThat(
-        getRequest(orgId, "scim").getStatusCode(), is(Status.NOT_FOUND.getStatusCode()));
+        postRequest(rep, orgId, "scim").getStatusCode(), is(Status.NOT_FOUND.getStatusCode()));
     assertThat(
-        postRequest(rep, orgId, "scim").getStatusCode(),
-        is(Status.NOT_FOUND.getStatusCode()));
-    assertThat(
-        putRequest(rep, orgId, "scim").getStatusCode(),
-        is(Status.NOT_FOUND.getStatusCode()));
-    assertThat(
-        deleteRequest(orgId, "scim").getStatusCode(),
-        is(Status.NOT_FOUND.getStatusCode()));
+        putRequest(rep, orgId, "scim").getStatusCode(), is(Status.NOT_FOUND.getStatusCode()));
+    assertThat(deleteRequest(orgId, "scim").getStatusCode(), is(Status.NOT_FOUND.getStatusCode()));
   }
 }

--- a/src/test/java/io/phasetwo/web/AbstractCypressOrganizationTest.java
+++ b/src/test/java/io/phasetwo/web/AbstractCypressOrganizationTest.java
@@ -113,11 +113,11 @@ public class AbstractCypressOrganizationTest {
             .withProviderClassesFrom("target/classes")
             .withProviderLibsFrom(getDeps())
             .withCustomCommand(
-                    "--spi-events-store-provider=" + MdcLoggerEventStoreProviderFactory.PROVIDER_ID)
+                "--spi-events-store-provider=" + MdcLoggerEventStoreProviderFactory.PROVIDER_ID)
             .withCustomCommand(
-                    "--spi-events-store-"
-                            + MdcLoggerEventStoreProviderFactory.PROVIDER_ID
-                            + "-use-jpa=true")
+                "--spi-events-store-"
+                    + MdcLoggerEventStoreProviderFactory.PROVIDER_ID
+                    + "-use-jpa=true")
             .withAccessToHost(true);
     if (isJacocoPresent()) {
       keycloakContainer =

--- a/src/test/java/io/phasetwo/web/CypressHomeIdpOrganizationTest.java
+++ b/src/test/java/io/phasetwo/web/CypressHomeIdpOrganizationTest.java
@@ -104,8 +104,8 @@ class CypressHomeIdpOrganizationTest extends AbstractCypressOrganizationTest {
             thirdIdentityProviderValidated -> {
               try {
                 setupKeycloakInstanceWithMultipleIdpsEnabledAtOrganization(); // sets up the
-                                                                              // keycloak with ~2
-                                                                              // IDP configs
+                // keycloak with ~2
+                // IDP configs
                 final var realm = findRealmByName("test-realm");
                 final var thirdClientRealm =
                     importRealm("/realms/external-idp.json", "third-external-idp");


### PR DESCRIPTION
## Summary

Fixes three independent bugs that, together, caused `401 Unauthorized` on the org admin endpoints (`/realms/<realm>/orgs/...`) when the caller's access token was a lightweight DPoP-bound token (issued by `security-admin-console` in recent Keycloak versions) or when the target realm was `master`. The Phase Two admin UI surfaced this as **"Could not fetch organizations configuration updates: HTTP 401 Unauthorized"** on Manage Settings, and a similar 401 when creating an org.

## Root causes

1. **DPoP double-validation** in `AbstractAdminResource.authenticateBearerToken`. The Keycloak request pipeline for `/realms/<realm>/...` paths validates the DPoP proof and consumes its JTI before our resource handler runs. Our authenticator then called `BearerTokenAuthenticator.authenticate()`, which re-runs `AuthenticationManager.verifyIdentityToken` with `DPoPUtil.withDPoPVerifier` wrapping. The second validation hits the replay store with the just-consumed JTI and fails with `"DPoP proof has already been used"`. Stock admin endpoints under `/admin/...` are not affected because their pipeline does not pre-validate the proof.

2. **`client.hasScope(role)` mismatch on master** in `OrganizationAdminAuth`. Keycloak's stock `AdminAuth.hasAppRole(app, role)` returns `user.hasRole(role) && client.hasScope(role)`. The scope predicate is meaningful for OIDC clients calling admin endpoints with their own access token. It is not meaningful here, because `AbstractAdminResource` synthesizes the `AdminAuth` `client` field as the *target* realm's master-admin-client — its scope is an accident of which client we picked. Master's master-admin-client (`master-realm`) and other realms' master-admin-clients (`<realm>-realm`) can have divergent scope configurations, which caused all `hasViewOrgs`/`hasManageOrgs`/`hasCreateOrg`/`hasManageRealm` checks to succeed on non-master realms and fail with 401 on master itself.

3. **Built-in `manage-realm` check duplicated locally** in `OrganizationsResource`. The two `/orgs/config` endpoints called the local `auth.hasManageRealm()` helper, which compounded #2's scope bug for a permission Keycloak's own admin permission evaluator already handles correctly.

## Changes

### `AbstractAdminResource.java`
- Replace `new AppAuthManager.BearerTokenAuthenticator(session).authenticate()` with a direct call to `AuthenticationManager.verifyIdentityToken(...)` using a **no-op verifier consumer**. Skips the DPoP wrapping; signature, issuer, audience and active checks still run. Inline comment documents why.

### `OrganizationAdminAuth.java`
- `@Override public boolean hasAppRole(ClientModel app, String role)` returning `roleModel != null && getUser().hasRole(roleModel)`. Drops the `client.hasScope(role)` predicate. Inline Javadoc documents the why and the master/non-master asymmetry.

### `OrganizationsResource.java`
- `GET /orgs/config` and `PUT /orgs/config`: replace `auth.hasManageRealm()` with `permissions.realm().canManageRealm()` (Keycloak's `AdminPermissionEvaluator`). Also fix two stale log messages ("Create org config..." → "Update"/"Get").

## Behavior preserved

- Status codes — still `NotAuthorizedException` (401) on denial, matching prior behavior. (Switching to `ForbiddenException`/403 would be more semantically correct but is API-visible; deferred.)
- Org-level permission helpers (`hasOrgViewOrg(org)`, etc.) unchanged — they were already model-only via `org.getRoleByName(...).hasRole(user)`.
- Custom org roles (`view-organizations`, `manage-organizations`, `create-organization`) still gate access; only the `client.hasScope` predicate is dropped from the implementation.

## Test plan

- [ ] `mvn install -DskipTests` builds.
- [ ] Existing test suite passes.
- [ ] Master realm admin → **Organizations → Manage Settings** opens without 401 (UI calls `GET /realms/master/orgs/config`).
- [ ] Master realm admin → **Create Organization** succeeds (`POST /realms/master/orgs`).
- [ ] Non-master realm admin via realm-specific `security-admin-console` → same flows succeed.
- [ ] Regression: existing realm-admin via `admin-cli` + classic Bearer access token still works.
