### PR TITLE
migrate to io.phasetwo oss-parent and replace spotify fmt with Spotless

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,106 @@
+# EditorConfig — Google Java Style Guide
+# Enforced at build time by fmt-maven-plugin (google-java-format).
+#
+# google-java-format is intentionally non-configurable; this file makes your
+# editor match what the formatter will produce so you see no diffs on save.
+#
+# References:
+#   https://google.github.io/styleguide/javaguide.html
+#   https://github.com/spotify/fmt-maven-plugin
+#   https://github.com/google/google-java-format
+
+root = true
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Defaults for every file in the project
+# ──────────────────────────────────────────────────────────────────────────────
+[*]
+charset                  = utf-8
+end_of_line              = lf
+insert_final_newline     = true
+trim_trailing_whitespace = true
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Java  — mirrors google-java-format output exactly
+#
+# Key rules from the Google Java Style Guide:
+#   § 2.3.1  UTF-8 source files
+#   § 3.1    One statement per line (handled by formatter)
+#   § 4.1    Braces: K&R style, always used (handled by formatter)
+#   § 4.2    Block indentation: +2 spaces (NOT tabs)
+#   § 4.3    One statement per line
+#   § 4.4    Column limit: 100 characters
+#   § 4.5.2  Continuation lines: +4 spaces (handled by formatter)
+#   § 4.6.1  Vertical whitespace (handled by formatter)
+#
+# Note: google-java-format hard-wraps at 100 columns and uses 2-space indent.
+#       There is no option to change either value — do not override them here.
+# ──────────────────────────────────────────────────────────────────────────────
+[*.java]
+indent_style             = space
+indent_size              = 2
+tab_width                = 2
+max_line_length          = 100
+insert_final_newline     = true
+trim_trailing_whitespace = true
+
+# IntelliJ IDEA — align with google-java-format output so saves don't produce diffs
+
+# Imports: prevent wildcard collapse (fmt always expands wildcards); static-first ordering
+ij_java_use_single_class_imports            = true
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_names_count_to_use_import_on_demand = 999
+ij_java_imports_layout                      = $*,|,*
+
+# Continuation indent: Google §4.5.2 specifies +4; IntelliJ defaults to 8
+ij_java_continuation_indent_size            = 4
+
+# Alignment: google-java-format never aligns params or chained calls; IntelliJ does by default
+ij_java_align_multiline_parameters          = false
+ij_java_align_multiline_chained_methods     = false
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Maven build files
+# ──────────────────────────────────────────────────────────────────────────────
+[*.xml]
+indent_style             = space
+indent_size              = 2
+max_line_length          = 120
+
+# ──────────────────────────────────────────────────────────────────────────────
+# IntelliJ IDEA project files
+# (keep consistent so VCS diffs stay clean)
+# ──────────────────────────────────────────────────────────────────────────────
+[*.iml]
+indent_style             = space
+indent_size              = 2
+
+[{.idea/**,*.ipr,*.iws}]
+indent_style             = space
+indent_size              = 2
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Properties & config files
+# ──────────────────────────────────────────────────────────────────────────────
+[*.properties]
+indent_style             = space
+indent_size              = 2
+
+[*.{yml,yaml}]
+indent_style             = space
+indent_size              = 2
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Shell scripts — keep LF even on Windows checkouts
+# ──────────────────────────────────────────────────────────────────────────────
+[*.sh]
+end_of_line              = lf
+indent_style             = space
+indent_size              = 2
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Markdown — trailing spaces are intentional line-breaks; don't trim them
+# ──────────────────────────────────────────────────────────────────────────────
+[*.md]
+trim_trailing_whitespace = false
+max_line_length          = off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: '0' # ratcheting 
       - name: Setup Java 21
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           git-release-bot-name: "phasetwo-bot"
           git-release-bot-email: "support@phasetwo.io"
 
-          maven-args: "-B -Dmaven.test.skip=true -DskipITs -Dmaven.deploy.skip=true"
+          maven-args: "-B -Dmaven.test.skip=true -DskipITs -Dmaven.deploy.skip=true -Dspotless.check.skip=true"
 
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The extensions herein are used in the [Phase Two](https://phasetwo.io) cloud off
   - [Overview](#overview)
     - [Definitions](#definitions)
   - [Quick start](#quick-start)
-  - [Building](#building)
+  - [Building and testing](#building-and-testing)
   - [Cypress-Test](#cypress-test)
   - [Installation](#installation)
     - [Admin UI](#admin-ui)
@@ -68,7 +68,19 @@ The easiest way to get started is our [Docker image](https://quay.io/repository/
 
 ## Building and testing
 
-Checkout this project and run `mvn clean install`, which will build the source, run all unit/integration tests, and produce a jar in the `target/` directory.
+Checkout this project and run `mvn clean install`, which will build the source, run all unit/integration tests, and produce a jar in the `target/` directory. The build enforces Google Java formatting standards via [Spotless](https://github.com/diffplug/spotless); run `mvn spotless:apply` to auto-format your code before committing.
+
+### Code formatting
+
+Spotless replaces the previously used Spotify `fmt-maven-plugin`. Use `mvn spotless:check` to verify formatting and `mvn spotless:apply` to fix it.
+
+To enforce formatting automatically before every push, install the provided git pre-push hook:
+
+```
+mvn spotless:install-git-pre-push-hook
+```
+
+When you push, the hook runs `spotless:check`. If violations are found, it automatically runs `spotless:apply`, aborts the push, and lets you review and commit the formatted files before retrying.
 
 ### Cypress tests
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.phasetwo.keycloak</groupId>
   <artifactId>keycloak-orgs</artifactId>
@@ -10,9 +11,9 @@
   <url>https://github.com/p2-inc/keycloak-orgs</url>
 
   <parent>
-    <groupId>com.github.xgp</groupId>
+    <groupId>io.phasetwo</groupId>
     <artifactId>oss-parent</artifactId>
-    <version>0.7</version>
+    <version>0.13</version>
   </parent>
 
   <developers>
@@ -71,7 +72,8 @@
                 </goals>
                 <configuration>
                   <target>
-                    <echo level="warn" message="[DEPRECATED] The cypress-tests profile is deprecated. Please use -Pintegration-tests instead, which runs Cypress and the database-compatibility smoke tests." />
+                    <echo level="warn"
+                          message="[DEPRECATED] The cypress-tests profile is deprecated. Please use -Pintegration-tests instead, which runs Cypress and the database-compatibility smoke tests."/>
                   </target>
                 </configuration>
               </execution>
@@ -211,24 +213,39 @@
 
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>3.6.0</version>
+          <configuration>
+            <java>
+              <excludes>
+                <exclude>src/main/java/io/phasetwo/service/auth/idp/*.java</exclude>
+                <exclude>src/main/java/io/phasetwo/service/auth/idp/**/*.java</exclude>
+              </excludes>
+            </java>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.3.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.12.0</version>
         <configuration>
-            <source>${java.version}</source>
+          <source>${java.version}</source>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
         <configuration>
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
           <source>${java.version}</source>
@@ -253,7 +270,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>1.4</version>
         <executions>
           <execution>
             <id>detect-scm-revision</id>
@@ -287,11 +303,6 @@
           <javaPackage>${main.java.package}</javaPackage>
           <versionCommit>${buildNumber}</versionCommit>
         </configuration>
-      </plugin>
-      <plugin> <!-- pretty up the code using google java standards `mvn fmt:format` -->
-        <groupId>com.spotify.fmt</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.29</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
 Follow-up on #467 and #468. Changes:

 - `pom.xml`: switch parent from `com.github.xgp:oss-parent:0.7` to `io.phasetwo:oss-parent:0.12-SNAPSHOT`; will be updated to 0.12.0 once      released; the parent now carries the Spotless plugin config, so the      local `fmt-maven-plugin` declaration is removed

 - `pom.xml`: add local Spotless `pluginManagement` to exclude the third-party      IdP discovery sources from formatting

 - `.github/workflows/ci.yml`: fetch full git history (`fetch-depth: 0`) for      Spotless

 - `.editorconfig`: add Google Java Style editor config

 - `README`: update building section to reference Spotless commands      (`spotless:apply` / `spotless:check`) and document the git pre-push hook
  