### PR TITLE
fix: support Keycloak 26.6.3 Cors API (allowedOrigins -> checkAllowedOrigins)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <main.java.package>io.phasetwo.service</main.java.package>
     <junit-jupiter.version>5.12.1</junit-jupiter.version>
-    <keycloak.version>26.6.1</keycloak.version>
+    <keycloak.version>26.6.3</keycloak.version>
     <keycloak-admin-client.version>26.0.9</keycloak-admin-client.version>
     <resteasy.version>6.2.12.Final</resteasy.version>
     <lombok.version>1.18.46</lombok.version>

--- a/src/main/java/io/phasetwo/service/resource/AbstractAdminResource.java
+++ b/src/main/java/io/phasetwo/service/resource/AbstractAdminResource.java
@@ -71,7 +71,7 @@ public abstract class AbstractAdminResource<T extends AdminAuth> {
   private void setupCors() {
     Cors.builder()
         .preflight()
-        .allowedOrigins(auth.getToken())
+        .checkAllowedOrigins(auth.getToken())
         .allowedMethods(CorsResource.METHODS)
         .exposedHeaders("Location")
         .auth()


### PR DESCRIPTION
## Summary

On Keycloak 26.6.3, every Organizations admin endpoint fails with:

```
java.lang.NoSuchMethodError: 'org.keycloak.services.cors.Cors org.keycloak.services.cors.Cors.allowedOrigins(org.keycloak.representations.AccessToken)'
    at io.phasetwo.service.resource.AbstractAdminResource.setupCors(AbstractAdminResource.java:74)
```

Keycloak 26.6.3 renamed the `Cors` builder method `allowedOrigins(...)` -> `checkAllowedOrigins(...)` as part of admin CORS/CSRF hardening (keycloak/keycloak#45957). `allowedOrigins(AccessToken)` no longer exists, so `AbstractAdminResource.setupCors()` throws `NoSuchMethodError` at runtime. The extension works on Keycloak <= 26.6.2.

## Change

- `AbstractAdminResource.setupCors()`: `allowedOrigins(auth.getToken())` -> `checkAllowedOrigins(auth.getToken())`
- `pom.xml`: `keycloak.version` `26.6.1` -> `26.6.3`

## Compatibility

`checkAllowedOrigins` does not exist before 26.6.3, so this targets **26.6.3+** and is not backwards-compatible with 26.6.2 and earlier.
