### PR TITLE
fix: honor account_hint over post-broker-login challenge for federated logins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -539,7 +539,7 @@
     <dependency>
       <groupId>io.phasetwo.keycloak</groupId>
       <artifactId>keycloak-events</artifactId>
-      <version>[0.45,)</version>
+      <version>[0.45,0.61)</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/phasetwo/service/auth/ActiveOrganizationAuthenticator.java
+++ b/src/main/java/io/phasetwo/service/auth/ActiveOrganizationAuthenticator.java
@@ -38,10 +38,13 @@ public class ActiveOrganizationAuthenticator implements Authenticator {
 
   @Override
   public void authenticate(AuthenticationFlowContext context) {
-    if (wasPostBrokerLogin(context)) {
-      tryOrganizationSelectionChallenge(context);
-    } else if (requestHasAccountHintParam(context)) {
+    // account_hint must be checked before wasPostBrokerLogin(): the latter is always true for
+    // federated (IdP) logins, so checking it first would always force the org-selection
+    // challenge and silently ignore account_hint for any SSO login.
+    if (requestHasAccountHintParam(context)) {
       evaluateAuthenticationWithAccountHint(context);
+    } else if (wasPostBrokerLogin(context)) {
+      tryOrganizationSelectionChallenge(context);
     } else if (shouldChallengeForOrganizationSelection(context)) {
       tryOrganizationSelectionChallenge(context);
     } else {

--- a/src/test/e2e/cypress/e2e/select-organization/account-hint-post-broker.cy.ts
+++ b/src/test/e2e/cypress/e2e/select-organization/account-hint-post-broker.cy.ts
@@ -1,0 +1,85 @@
+/**
+ * E2E: account_hint with post-broker login
+ *
+ * Verifies that account_hint=<org-id> passed in the original OIDC auth request
+ * survives the IdP round-trip and auto-selects the correct org during post-broker
+ * flow execution, skipping the org-picker UI.
+ *
+ * Setup (done by CypressAccountHintPostBrokerTest.java):
+ *   - idp-test-user (test@phasetwo.io) is member of org-1 and org-2
+ *   - oidc-idp is linked to org-1 with postBrokerLoginFlowAlias = "custom-post-broker-login",
+ *     a flow that adds ext-select-org after the default org bookkeeping steps -- without it,
+ *     ext-select-org never runs post-broker and account_hint is never evaluated
+ */
+
+import { testRealmLoginUri, loginUriAccountHint } from "../../fixtures/uri";
+import { getRealmOrganizations, org1Name, org2Name } from "../../utils/organizations";
+
+const idpUser = {
+  username: "test@phasetwo.io",
+  password: "test123",
+  email: "test@phasetwo.io",
+};
+
+const loginViaIdp = (loginUrl: string) => {
+  cy.visit(loginUrl);
+  // home-IdP discovery: type email → discovered → redirect to external IdP
+  cy.get("#username").type(idpUser.email);
+  cy.get("#kc-login").click();
+  // now on external-idp login page
+  cy.url().should("include", "external-idp");
+  cy.get("#username").type(idpUser.username);
+  cy.get("#password").type(idpUser.password);
+  cy.get("#kc-login").click();
+};
+
+beforeEach(() => {
+  cy.clearCookies();
+});
+
+describe("account_hint with post-broker login — org auto-selection", () => {
+  it("account_hint=org1 skips org picker and activates org-1", () => {
+    getRealmOrganizations().then((orgs) => {
+      const org1 = orgs.find((o) => o.name === org1Name);
+
+      loginViaIdp(loginUriAccountHint + org1.id);
+
+      // post-broker flow ran: account_hint matched → no picker shown
+      cy.get('[data-cy="select-org-label"]').should("not.exist");
+      cy.contains("Personal");
+
+      // verify org-1 is now the active org
+      cy.validateActiveOrganization(idpUser, org1Name);
+    });
+  });
+
+  it("account_hint=org2 skips org picker and activates org-2", () => {
+    getRealmOrganizations().then((orgs) => {
+      const org2 = orgs.find((o) => o.name === org2Name);
+
+      loginViaIdp(loginUriAccountHint + org2.id);
+
+      cy.get('[data-cy="select-org-label"]').should("not.exist");
+      cy.contains("Personal");
+
+      cy.validateActiveOrganization(idpUser, org2Name);
+    });
+  });
+});
+
+describe("account_hint with post-broker login — fallback behaviour", () => {
+  it("no account_hint and user in 2 orgs shows org picker after IdP login", () => {
+    loginViaIdp(testRealmLoginUri + "&prompt=select_account");
+
+    // post-broker flow ran: no hint → picker shown because user has 2 orgs
+    cy.get('[data-cy="select-org-label"]').should("exist");
+    cy.get('[data-cy="select-org-options"]').should("have.length", 2);
+  });
+
+  it("invalid account_hint returns invalidOrganizationError after IdP login", () => {
+    loginViaIdp(loginUriAccountHint + "non-existent-org-id");
+
+    cy.get("#kc-error-message").should("exist");
+    cy.contains("Invalid");
+  });
+});

--- a/src/test/e2e/cypress/e2e/select-organization/account-hint-post-broker.cy.ts
+++ b/src/test/e2e/cypress/e2e/select-organization/account-hint-post-broker.cy.ts
@@ -69,7 +69,7 @@ describe("account_hint with post-broker login — org auto-selection", () => {
 
 describe("account_hint with post-broker login — fallback behaviour", () => {
   it("no account_hint and user in 2 orgs shows org picker after IdP login", () => {
-    loginViaIdp(testRealmLoginUri + "&prompt=select_account");
+    loginViaIdp(testRealmLoginUri);
 
     // post-broker flow ran: no hint → picker shown because user has 2 orgs
     cy.get('[data-cy="select-org-label"]').should("exist");

--- a/src/test/java/io/phasetwo/web/CypressAccountHintPostBrokerTest.java
+++ b/src/test/java/io/phasetwo/web/CypressAccountHintPostBrokerTest.java
@@ -43,7 +43,7 @@ import org.testcontainers.Testcontainers;
  *   - org-1 (domain phasetwo.io) linked to oidc-idp, with postBrokerLoginFlowAlias set to a
  *     custom flow (createCustomPostBrokerLoginFlow) that adds ext-select-org after the default
  *     org bookkeeping steps -- without it, account_hint is never evaluated post-broker
- *   - org-2 (no domain)
+ *   - org-2 (domain org2.com)
  *   - idp-test-user member of both orgs, federated identity linked to oidc-idp by the external
  *     realm's actual user id (not email, which Keycloak doesn't recognize as pre-linked)
  *
@@ -111,7 +111,7 @@ class CypressAccountHintPostBrokerTest extends AbstractCypressOrganizationTest {
             testRealm,
             new OrganizationRepresentation().name("org-1").domains(List.of("phasetwo.io")));
 
-    // 5. create org-2 without domain
+    // 5. create org-2 with domain org2.com
     OrganizationRepresentation org2 =
         createOrganization(
             testRealm, new OrganizationRepresentation().name("org-2").domains(List.of("org2.com")));

--- a/src/test/java/io/phasetwo/web/CypressAccountHintPostBrokerTest.java
+++ b/src/test/java/io/phasetwo/web/CypressAccountHintPostBrokerTest.java
@@ -1,0 +1,300 @@
+package io.phasetwo.web;
+
+import static io.phasetwo.service.Helpers.toJsonString;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableMap;
+import io.github.wimdeblauwe.testcontainers.cypress.CypressContainer;
+import io.github.wimdeblauwe.testcontainers.cypress.CypressTestResults;
+import io.phasetwo.client.openapi.model.OrganizationRepresentation;
+import io.phasetwo.service.representation.LinkIdp;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
+import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
+import org.keycloak.representations.idm.FederatedIdentityRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.testcontainers.Testcontainers;
+
+/**
+ * E2E test: account_hint survives post-broker login.
+ *
+ * Prior to this test, ext-select-org was never invoked during the post-broker-login phase in
+ * any existing test -- phasetwo's default post-broker flow ("post org broker login") only does
+ * org bookkeeping (verify idp, add user to org, set org note) and does not include ext-select-org.
+ * The interaction between account_hint and a federated (IdP) login therefore had zero coverage
+ * before this test: existing select-organization-by-id.cy.ts / select-organization-by-name.cy.ts
+ * only exercise account_hint / prompt=select_account for direct username/password login.
+ *
+ * Setup:
+ *   - test-realm with home-IdP discovery browser flow
+ *   - external-idp realm as OIDC IdP (user: test@phasetwo.io / test123)
+ *   - org-1 (domain phasetwo.io) linked to oidc-idp, with postBrokerLoginFlowAlias set to a
+ *     custom flow (createCustomPostBrokerLoginFlow) that adds ext-select-org after the default
+ *     org bookkeeping steps -- without it, account_hint is never evaluated post-broker
+ *   - org-2 (no domain)
+ *   - idp-test-user member of both orgs, federated identity linked to oidc-idp by the external
+ *     realm's actual user id (not email, which Keycloak doesn't recognize as pre-linked)
+ *
+ * Scenarios exercised by the Cypress spec:
+ *   1. Login via IdP + account_hint=org1 → org-1 auto-selected, no picker
+ *   2. Login via IdP + account_hint=org2 → org-2 auto-selected, no picker
+ *   3. Login via IdP, no hint, 2 orgs     → org picker shown
+ *   4. Login via IdP + account_hint=bad   → invalidOrganizationError
+ */
+@EnabledIfSystemProperty(named = "include.cypress", matches = "true")
+@org.testcontainers.junit.jupiter.Testcontainers
+class CypressAccountHintPostBrokerTest extends AbstractCypressOrganizationTest {
+
+  private static final String IDP_ALIAS = "oidc-idp";
+  private static final String IDP_USER_EMAIL = "test@phasetwo.io";
+  private static final String IDP_USER_PASS = "test123";
+  // ext-select-org isn't part of phasetwo's default "post org broker login" flow (org
+  // bookkeeping only), so it must be added to a custom post-broker-login flow for the
+  // account_hint fix to actually be exercised after a federated login.
+  private static final String POST_BROKER_FLOW_ALIAS = "custom-post-broker-login";
+
+  @TestFactory
+  List<DynamicContainer> runAccountHintPostBrokerTests()
+      throws IOException, InterruptedException, TimeoutException {
+
+    Testcontainers.exposeHostPorts(container.getHttpPort());
+    setupTestEnv();
+
+    try (CypressContainer cypressContainer =
+        new CypressContainer()
+            .withBaseUrl(
+                "http://host.testcontainers.internal:" + container.getHttpPort() + "/auth/")
+            .withSpec("cypress/e2e/select-organization/account-hint-post-broker.cy.ts")
+            .withBrowser("electron")) {
+      cypressContainer.start();
+      CypressTestResults results = cypressContainer.getTestResults();
+      cleanupKeycloakInstance();
+      return convertToJUnitDynamicTests(results);
+    }
+  }
+
+  // ── setup ─────────────────────────────────────────────────────────────────
+
+  private void setupTestEnv() throws IOException {
+    // 1. import test realm (home-IdP discovery browser flow + public-client)
+    RealmRepresentation testRealm =
+        importRealm("/realms/kc-realm-account-hint-post-broker.json", null);
+
+    // 2. import external IdP realm
+    RealmRepresentation externalIdpRealm = importRealm("/realms/external-idp.json", null);
+
+    // 3. create IdP in test-realm pointing at external-idp realm
+    IdentityProviderRepresentation idp = buildIdpRepresentation(IDP_ALIAS, "external-idp");
+    var createIdpResp = keycloak.realm("test-realm").identityProviders().create(idp);
+    assertThat(createIdpResp.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+    // re-read to get full representation (including internalId)
+    idp = keycloak.realm("test-realm").identityProviders().get(IDP_ALIAS).toRepresentation();
+
+    // update redirect URI in external-idp client to match container port
+    updateRedirectUri(externalIdpRealm, idp);
+
+    // 4. create org-1 with domain phasetwo.io
+    OrganizationRepresentation org1 =
+        createOrganization(
+            testRealm,
+            new OrganizationRepresentation().name("org-1").domains(List.of("phasetwo.io")));
+
+    // 5. create org-2 without domain
+    OrganizationRepresentation org2 =
+        createOrganization(
+            testRealm, new OrganizationRepresentation().name("org-2").domains(List.of("org2.com")));
+
+    // 6. create a custom post-broker-login flow (org bookkeeping + ext-select-org) and link
+    // the IdP to org-1 using it, so account_hint is actually evaluated after federated login
+    createCustomPostBrokerLoginFlow(testRealm);
+    linkIdpToOrg(testRealm, org1, IDP_ALIAS);
+
+    // 7. create the IdP user in test-realm so org membership can be set before first browser login
+    String userId = createIdpUserInTestRealm(testRealm);
+
+    // 8. link federated identity so IdP login maps to this user
+    addFederatedIdentity(testRealm, userId);
+
+    // 9. add user to both orgs
+    addMembership(testRealm, org1.getId(), userId);
+    addMembership(testRealm, org2.getId(), userId);
+
+    // 10. grant account-console roles so the account page loads
+    assignAccountRoles(testRealm, userId);
+  }
+
+  private IdentityProviderRepresentation buildIdpRepresentation(
+      String alias, String externalRealmId) {
+    IdentityProviderRepresentation idp = new IdentityProviderRepresentation();
+    idp.setAlias(alias);
+    idp.setProviderId("oidc");
+    idp.setEnabled(true);
+    idp.setFirstBrokerLoginFlowAlias("first broker login");
+    idp.setConfig(
+        new ImmutableMap.Builder<String, String>()
+            .put("useJwksUrl", "true")
+            .put("syncMode", "FORCE")
+            .put(
+                "authorizationUrl",
+                "http://host.testcontainers.internal:%s/auth/realms/%s/protocol/openid-connect/auth"
+                    .formatted(container.getHttpPort(), externalRealmId))
+            .put(
+                "tokenUrl",
+                "http://host.testcontainers.internal:%s/auth/realms/%s/protocol/openid-connect/token"
+                    .formatted(container.getHttpPort(), externalRealmId))
+            .put("clientAuthMethod", "client_secret_post")
+            .put("clientId", "test-realm-client")
+            .put("clientSecret", "secret-123")
+            .put("hideOnLoginPage", "")
+            .put("loginHint", "")
+            .put("validateSignature", "")
+            .put("pkceEnabled", "")
+            .build());
+    return idp;
+  }
+
+  private void updateRedirectUri(
+      RealmRepresentation externalIdpRealm, IdentityProviderRepresentation idp) {
+    String redirectUri =
+        "http://host.testcontainers.internal:%s/auth/realms/test-realm/broker/%s/endpoint"
+            .formatted(container.getHttpPort(), idp.getAlias());
+    var clientRep =
+        keycloak
+            .realm(externalIdpRealm.getRealm())
+            .clients()
+            .findByClientId("test-realm-client")
+            .get(0);
+    clientRep.setRedirectUris(List.of(redirectUri));
+    keycloak.realm(externalIdpRealm.getRealm()).clients().get(clientRep.getId()).update(clientRep);
+  }
+
+  private void createCustomPostBrokerLoginFlow(RealmRepresentation testRealm) {
+    var flowsRes = keycloak.realm(testRealm.getRealm()).flows();
+
+    AuthenticationFlowRepresentation flow = new AuthenticationFlowRepresentation();
+    flow.setAlias(POST_BROKER_FLOW_ALIAS);
+    flow.setProviderId("basic-flow");
+    flow.setTopLevel(true);
+    flow.setBuiltIn(false);
+    flowsRes.createFlow(flow);
+
+    for (String provider :
+        List.of(
+            "ext-auth-org-note",
+            "ext-auth-org-add-user",
+            "ext-auth-validate-idp",
+            "ext-select-org")) {
+      Map<String, Object> params = new HashMap<>();
+      params.put("provider", provider);
+      flowsRes.addExecution(POST_BROKER_FLOW_ALIAS, params);
+    }
+
+    for (AuthenticationExecutionInfoRepresentation execution :
+        flowsRes.getExecutions(POST_BROKER_FLOW_ALIAS)) {
+      execution.setRequirement("REQUIRED");
+      flowsRes.updateExecutions(POST_BROKER_FLOW_ALIAS, execution);
+    }
+  }
+
+  private void linkIdpToOrg(
+      RealmRepresentation testRealm, OrganizationRepresentation org, String idpAlias)
+      throws com.fasterxml.jackson.core.JsonProcessingException {
+    LinkIdp link = new LinkIdp();
+    link.setAlias(idpAlias);
+    link.setSyncMode("IMPORT");
+    link.setPostBrokerFlow(POST_BROKER_FLOW_ALIAS);
+    var resp =
+        given()
+            .baseUri(container.getAuthServerUrl())
+            .basePath("realms/" + testRealm.getRealm() + "/orgs/" + org.getId() + "/idps/link")
+            .contentType("application/json")
+            .auth()
+            .oauth2(keycloak.tokenManager().getAccessTokenString())
+            .body(toJsonString(link))
+            .when()
+            .post()
+            .then()
+            .extract()
+            .response();
+    assertThat(resp.getStatusCode(), is(Response.Status.CREATED.getStatusCode()));
+  }
+
+  private String createIdpUserInTestRealm(RealmRepresentation testRealm) {
+    UserRepresentation user = new UserRepresentation();
+    user.setUsername(IDP_USER_EMAIL);
+    user.setEmail(IDP_USER_EMAIL);
+    user.setEmailVerified(true);
+    user.setEnabled(true);
+    user.setFirstName("Test");
+    user.setLastName("User");
+    // password credential allows validateActiveOrganization to get a token via direct grant
+    org.keycloak.representations.idm.CredentialRepresentation cred =
+        new org.keycloak.representations.idm.CredentialRepresentation();
+    cred.setType("password");
+    cred.setValue(IDP_USER_PASS);
+    cred.setTemporary(false);
+    user.setCredentials(List.of(cred));
+
+    var resp = keycloak.realm(testRealm.getRealm()).users().create(user);
+    assertThat(resp.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+    String location = resp.getHeaderString("Location");
+    return location.substring(location.lastIndexOf("/") + 1);
+  }
+
+  private void addFederatedIdentity(RealmRepresentation testRealm, String userId) {
+    // must be the external realm's actual user id (matches the OIDC "sub" claim the broker
+    // receives), not the email -- otherwise Keycloak doesn't recognize the incoming federated
+    // login as already-linked and runs first-broker-login ("Account already exists") instead
+    String externalUserId =
+        keycloak.realm("external-idp").users().searchByEmail(IDP_USER_EMAIL, true).get(0).getId();
+
+    FederatedIdentityRepresentation fedId = new FederatedIdentityRepresentation();
+    fedId.setIdentityProvider(IDP_ALIAS);
+    fedId.setUserId(externalUserId);
+    fedId.setUserName(IDP_USER_EMAIL);
+    var resp =
+        keycloak
+            .realm(testRealm.getRealm())
+            .users()
+            .get(userId)
+            .addFederatedIdentity(IDP_ALIAS, fedId);
+    assertThat(resp.getStatus(), is(Response.Status.NO_CONTENT.getStatusCode()));
+  }
+
+  private void addMembership(RealmRepresentation testRealm, String orgId, String userId)
+      throws com.fasterxml.jackson.core.JsonProcessingException {
+    var resp =
+        given()
+            .baseUri(container.getAuthServerUrl())
+            .basePath("realms/" + testRealm.getRealm() + "/orgs/" + orgId + "/members/" + userId)
+            .contentType("application/json")
+            .auth()
+            .oauth2(keycloak.tokenManager().getAccessTokenString())
+            .body(toJsonString(""))
+            .when()
+            .put()
+            .then()
+            .extract()
+            .response();
+    assertThat(resp.getStatusCode(), is(Response.Status.CREATED.getStatusCode()));
+  }
+
+  private void assignAccountRoles(RealmRepresentation testRealm, String userId) {
+    var realmRes = keycloak.realm(testRealm.getRealm());
+    var accountClient = realmRes.clients().findByClientId("account").getFirst();
+    var roles = realmRes.clients().get(accountClient.getId()).roles().list();
+    realmRes.users().get(userId).roles().clientLevel(accountClient.getId()).add(roles);
+  }
+}

--- a/src/test/resources/realms/kc-realm-account-hint-post-broker.json
+++ b/src/test/resources/realms/kc-realm-account-hint-post-broker.json
@@ -1,0 +1,105 @@
+{
+  "realm": "test-realm",
+  "enabled": true,
+  "clients": [
+    {
+      "clientId": "public-client",
+      "name": "public-client",
+      "protocol": "openid-connect",
+      "enabled": true,
+      "publicClient": true,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": true,
+      "rootUrl": "http://localhost:3000",
+      "baseUrl": "http://localhost:3000",
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "defaultClientScopes": [
+        "web-origins", "acr", "roles", "profile", "basic", "email"
+      ]
+    }
+  ],
+  "authenticationFlows": [
+    {
+      "alias": "Copy of browser",
+      "description": "Browser based authentication with home IdP discovery",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Copy of browser forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "alias": "Copy of browser forms",
+      "description": "Username form with home IdP discovery",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "ext-auth-home-idp-discovery",
+          "authenticator": "ext-auth-home-idp-discovery",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 1,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "alias": "ext-auth-home-idp-discovery",
+      "config": {
+        "requireVerifiedDomain": "false",
+        "requireVerifiedEmail": "false",
+        "forwardToFirstMatch": "true",
+        "bypassLoginPage": "false",
+        "userAttribute": "email",
+        "forwardToLinkedIdp": "true"
+      }
+    }
+  ],
+  "browserFlow": "Copy of browser"
+}


### PR DESCRIPTION
## Summary
- `ActiveOrganizationAuthenticator` checked `wasPostBrokerLogin()` before `account_hint`, so any IdP login forced the org-selection challenge and ignored `account_hint`. Check `account_hint` first; fall back to the post-broker/prompt challenge only when there's no hint.
- Fixes `account-hint-post-broker` test setup: link the federated identity by the external realm's real user id, not email (Keycloak won't recognize the login as pre-linked otherwise). Route the IdP's post-broker flow through a custom flow that includes `ext-select-org` (the default post-broker flow only does org bookkeeping).
- Pin `keycloak-events` below `0.61` in `pom.xml`. A provider-enablement regression there breaks Testcontainers boot for every Cypress test; pre-existing, unrelated to this change.

## Manual validation
Validated against a live Keycloak container, independent of the automated test:
- Realm with home-IdP discovery; `oidc-idp` linked to `org-1` via a custom post-broker-login flow (org bookkeeping + `ext-select-org`); user is a member of both `org-1` and `org-2`.
- Full redirect chain (discovery, external IdP, broker callback, post-broker-login, token) via curl and manually in a browser.
- `account_hint=org-1` → direct success, no picker; `active_organization` claim is `org-1`.
- `account_hint=org-2` → same, resolves to `org-2`.
- No hint, user in 2 orgs → org picker shown; submitted choice persists into `active_organization`.

## Test coverage
New: `CypressAccountHintPostBrokerTest` / `account-hint-post-broker.cy.ts`, 4 scenarios exercising `ActiveOrganizationAuthenticator.authenticate()` in a real post-broker-login context:
1. `account_hint=org1` → org-1 auto-selected, no picker
2. `account_hint=org2` → org-2 auto-selected, no picker
3. No hint, 2 orgs → org picker shown
4. Invalid `account_hint` → `invalidOrganizationError`

Before this, `ext-select-org` was never invoked post-broker in any test, so `account_hint` + federated login had no coverage. `select-organization-by-id.cy.ts` / `select-organization-by-name.cy.ts` only cover `account_hint`/`prompt=select_account` for direct username/password login, no IdP/broker.

`mvn test -Pintegration-tests -Dtest=CypressAccountHintPostBrokerTest` — 4/4 passing.