### PR TITLE
test: add keycloak-scim-server to Cypress test container provider libs

### DIFF
--- a/src/test/java/io/phasetwo/web/AbstractCypressOrganizationTest.java
+++ b/src/test/java/io/phasetwo/web/AbstractCypressOrganizationTest.java
@@ -80,7 +80,8 @@ public class AbstractCypressOrganizationTest {
     "org.jboss.resteasy:resteasy-client",
     "org.jboss.resteasy:resteasy-client-api",
     "org.keycloak:keycloak-admin-client",
-    "io.phasetwo.keycloak:keycloak-events"
+    "io.phasetwo.keycloak:keycloak-events",
+    "io.phasetwo.keycloak:keycloak-scim-server"
   };
 
   static List<File> getDeps() {


### PR DESCRIPTION
## Summary
- Cypress/Testcontainers-based tests load provider jars from a fixed `deps` list in `AbstractCypressOrganizationTest`. `io.phasetwo.keycloak:keycloak-scim-server` was missing from that list, so the SCIM federation provider classes weren't available to the Keycloak container started for these tests.