### PR TITLE
Fix NPE in OrganizationAdapter.getMembersStream on orphaned membership rows

### DIFF
--- a/src/main/java/io/phasetwo/service/model/jpa/OrganizationAdapter.java
+++ b/src/main/java/io/phasetwo/service/model/jpa/OrganizationAdapter.java
@@ -22,10 +22,20 @@ import io.phasetwo.service.model.jpa.entity.UserOrganizationRoleMappingEntity;
 import io.phasetwo.service.util.IdentityProviders;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
-import jakarta.persistence.criteria.*;
-import java.util.*;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.From;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jboss.logging.Logger;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
@@ -36,6 +46,8 @@ import org.keycloak.models.jpa.entities.UserEntity;
 import org.keycloak.models.utils.KeycloakModelUtils;
 
 public class OrganizationAdapter implements OrganizationModel, JpaModel<ExtOrganizationEntity> {
+
+  private static final Logger log = Logger.getLogger(OrganizationAdapter.class);
 
   protected final KeycloakSession session;
   protected final ExtOrganizationEntity org;
@@ -241,7 +253,7 @@ public class OrganizationAdapter implements OrganizationModel, JpaModel<ExtOrgan
     return closing(paginateQuery(query, firstResult, maxResults).getResultStream())
         .filter(Objects::nonNull)
         .map(OrganizationMemberEntity::getUserId)
-        .map(userId -> session.users().getUserById(realm, userId))
+        .map(this::getMemberUserOrWarn)
         .filter(Objects::nonNull)
         .filter(u -> u.getServiceAccountClientLink() == null);
   }
@@ -331,8 +343,20 @@ public class OrganizationAdapter implements OrganizationModel, JpaModel<ExtOrgan
         .getResultStream()
         .filter(Objects::nonNull)
         .map(OrganizationMemberEntity::getUserId)
-        .map(userId -> session.users().getUserById(realm, userId))
+        .map(this::getMemberUserOrWarn)
+        .filter(Objects::nonNull)
         .filter(u -> u.getServiceAccountClientLink() == null);
+  }
+
+  private UserModel getMemberUserOrWarn(String userId) {
+    UserModel user = session.users().getUserById(realm, userId);
+    if (user == null) {
+      log.warnf(
+          "Organization %s has a membership record for user %s, but no user with that id exists."
+              + " Skipping this member.",
+          org.getId(), userId);
+    }
+    return user;
   }
 
   @Override

--- a/src/test/java/io/phasetwo/service/importexport/OrganizationMemberOrphanedUserExportTest.java
+++ b/src/test/java/io/phasetwo/service/importexport/OrganizationMemberOrphanedUserExportTest.java
@@ -1,0 +1,191 @@
+package io.phasetwo.service.importexport;
+
+import static io.phasetwo.service.AbstractOrganizationTest.KEYCLOAK_IMAGE;
+import static io.phasetwo.service.AbstractOrganizationTest.getDeps;
+import static io.phasetwo.service.Helpers.createUser;
+import static io.phasetwo.service.Helpers.objectMapper;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.phasetwo.client.openapi.model.OrganizationRepresentation;
+import io.phasetwo.service.KeycloakOrgsAdminAPI;
+import io.phasetwo.service.importexport.representation.KeycloakOrgsRepresentation;
+import io.restassured.response.Response;
+import jakarta.ws.rs.core.Response.Status;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Reproduces the NPE reported from production logs:
+ *
+ * <pre>
+ * java.lang.NullPointerException: Cannot invoke "org.keycloak.models.UserModel.getServiceAccountClientLink()"
+ * because "u" is null
+ *   at io.phasetwo.service.model.jpa.OrganizationAdapter.lambda$getMembersStream$1(OrganizationAdapter.java:335)
+ * </pre>
+ *
+ * <p>{@code ORGANIZATION_MEMBER.USER_ID} has no foreign key to the Keycloak user table, so a
+ * membership row can outlive the user it references (e.g. the user was deleted through a path
+ * that bypassed the {@code UserModel.UserRemovedEvent} listener). {@code
+ * OrganizationAdapter#getMembersStream} looks the user up by that id and, unlike its sibling
+ * {@code searchForMembersStream}, does not filter out a null result before dereferencing it. This
+ * test simulates the orphaned row directly via JDBC (no FK stops it) and drives the one
+ * REST-reachable caller of the unfiltered method: {@code GET .../orgs/export?exportMembersAndInvitations=true}.
+ */
+public class OrganizationMemberOrphanedUserExportTest {
+
+  private static final Network network = Network.newNetwork();
+
+  private static final PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>("postgres:16")
+          .withNetwork(network)
+          .withNetworkAliases("postgres")
+          .withDatabaseName("keycloak")
+          .withUsername("keycloak")
+          .withPassword("password");
+
+  private static final KeycloakContainer keycloakContainer =
+      new KeycloakContainer(KEYCLOAK_IMAGE)
+          .withNetwork(network)
+          .withContextPath("/auth")
+          .withProviderClassesFrom("target/classes")
+          .withProviderLibsFrom(getDeps())
+          .withEnv("KC_DB", "postgres")
+          .withEnv("KC_DB_URL", "jdbc:postgresql://postgres:5432/keycloak?loggerLevel=OFF")
+          .withEnv("KC_DB_USERNAME", postgres.getUsername())
+          .withEnv("KC_DB_PASSWORD", postgres.getPassword())
+          .withAccessToHost(true);
+
+  private static final String REALM = "master";
+
+  private static Keycloak keycloak;
+
+  @BeforeAll
+  public static void setUp() {
+    postgres.start();
+    keycloakContainer.start();
+
+    keycloak =
+        Keycloak.getInstance(
+            keycloakContainer.getAuthServerUrl(),
+            REALM,
+            keycloakContainer.getAdminUsername(),
+            keycloakContainer.getAdminPassword(),
+            "admin-cli");
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    if (keycloakContainer != null) {
+      keycloakContainer.stop();
+    }
+    if (postgres != null) {
+      postgres.stop();
+    }
+    if (network != null) {
+      network.close();
+    }
+  }
+
+  private KeycloakOrgsAdminAPI orgsApi() {
+    return new KeycloakOrgsAdminAPI(keycloakContainer.getAuthServerUrl(), REALM, keycloak);
+  }
+
+  @Test
+  @DisplayName(
+      "Export with an orphaned ORGANIZATION_MEMBER row (user deleted outside the event listener) "
+          + "should not NPE, and should skip the orphaned member")
+  void exportSkipsOrphanedMembershipInsteadOfThrowing() throws Exception {
+    // one real member, added through the normal REST flow
+    UserRepresentation member = createUser(keycloak, REALM, "orgmember-" + UUID.randomUUID());
+
+    OrganizationRepresentation org =
+        orgsApi().createOrganization(new OrganizationRepresentation().name("orphan-member-org"));
+
+    addMember(org.getId(), member.getId());
+
+    // simulate a membership row whose user no longer exists. USER_ID has no FK to the Keycloak
+    // user table, so this state is reachable in production (e.g. a user removed by a path that
+    // skips the UserRemovedEvent listener in OrganizationResourceProviderFactory), not just a
+    // theoretical DB state.
+    insertOrphanedMembership(org.getId());
+
+    Response exportResponse =
+        given()
+            .baseUri(keycloakContainer.getAuthServerUrl())
+            .basePath("realms/" + REALM + "/orgs")
+            .contentType("application/json")
+            .auth()
+            .oauth2(keycloak.tokenManager().getAccessTokenString())
+            .queryParam("exportMembersAndInvitations", true)
+            .when()
+            .get("export")
+            .andReturn();
+
+    // Before the fix: getMembersStream() NPEs on the orphaned row and the whole export 500s.
+    assertThat(
+        "export should succeed instead of 500ing on the orphaned membership row",
+        exportResponse.getStatusCode(),
+        is(Status.OK.getStatusCode()));
+
+    KeycloakOrgsRepresentation export =
+        objectMapper()
+            .readValue(exportResponse.getBody().asString(), KeycloakOrgsRepresentation.class);
+
+    var exportedOrg =
+        export.getOrganizations().stream()
+            .filter(o -> o.getOrganization().getName().equals(org.getName()))
+            .findFirst()
+            .orElseThrow();
+
+    // the orphaned row must be skipped, not surfaced as a phantom member
+    assertThat(exportedOrg.getMembers(), hasSize(1));
+    assertThat(
+        exportedOrg.getMembers().stream().map(m -> m.getUsername()).toList(),
+        contains(member.getUsername()));
+  }
+
+  private void addMember(String orgId, String userId) {
+    Response response =
+        given()
+            .baseUri(keycloakContainer.getAuthServerUrl())
+            .basePath("realms/" + REALM + "/orgs")
+            .contentType("application/json")
+            .auth()
+            .oauth2(keycloak.tokenManager().getAccessTokenString())
+            .when()
+            .put(orgId + "/members/" + userId)
+            .andReturn();
+    assertThat(response.getStatusCode(), is(Status.CREATED.getStatusCode()));
+  }
+
+  private void insertOrphanedMembership(String orgId) throws SQLException {
+    try (Connection conn =
+            DriverManager.getConnection(
+                postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+        PreparedStatement ps =
+            conn.prepareStatement(
+                "INSERT INTO organization_member (id, created_at, user_id, organization_id) "
+                    + "VALUES (?, now(), ?, ?)")) {
+      ps.setString(1, UUID.randomUUID().toString());
+      ps.setString(2, UUID.randomUUID().toString()); // no matching USER_ENTITY row, by design
+      ps.setString(3, orgId);
+      ps.executeUpdate();
+    }
+  }
+}


### PR DESCRIPTION
Fixes #480

## Problem

`OrganizationAdapter.getMembersStream(boolean)` NPEs when an `ORGANIZATION_MEMBER` row's `USER_ID` no longer resolves to an existing user:

```
java.lang.NullPointerException: Cannot invoke "org.keycloak.models.UserModel.getServiceAccountClientLink()" because "u" is null
    at io.phasetwo.service.model.jpa.OrganizationAdapter.lambda$getMembersStream$1(OrganizationAdapter.java:335)
```

`ORGANIZATION_MEMBER.USER_ID` has no FK to the Keycloak user table, so this state is reachable whenever a user is removed through a path that bypasses the `UserModel.UserRemovedEvent` listener in `OrganizationResourceProviderFactory` (direct DB deletion/migration, federation sync removing the backing user, or that listener's cleanup call throwing and being swallowed). `getMembersStream` looked the user up and dereferenced the result without a null check; its sibling `searchForMembersStream` already guarded against exactly this.

## Fix

Both methods now go through a shared `getMemberUserOrWarn` helper that returns `null` (filtered out downstream) and logs a `WARN` identifying the organization and the dangling user id, instead of crashing.

## Why not `@JBossLog`

This class already has an instance field named `org` (`ExtOrganizationEntity org`). Lombok's logger annotations (`@JBossLog` included) generate the logger field using the fully-qualified type name, e.g.:

```java
private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(OrganizationAdapter.class);
```

Because the class has a field literally named `org`, that reference resolves to the field instead of the `org` package, and the build fails with `non-static variable org cannot be referenced from a static context`. So this PR adds the logger manually (`import org.jboss.logging.Logger; private static final Logger log = Logger.getLogger(OrganizationAdapter.class);`) — same underlying JBoss `Logger` class and `log.warnf(...)` API used everywhere else in the codebase, just without the annotation.

## Test plan

- Added `OrganizationMemberOrphanedUserExportTest`, which inserts an orphaned `ORGANIZATION_MEMBER` row via JDBC (pointing at a random, non-existent user id — legal since there's no FK) and drives it through `GET .../orgs/export?exportMembersAndInvitations=true`, the one REST-reachable caller of the unfiltered `getMembersStream`.
  - Confirmed this test fails against `main` (500, with the exact reported NPE in the container logs).
  - Passes after this fix; the export succeeds, the orphaned row is skipped, and the real member is still returned.
- Ran the existing `OrganizationMembersExportTest` suite — still green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)