### PR TITLE
Offer passkeys (WebAuthn conditional UI) on the Home IdP Discovery username step

### DIFF
--- a/src/main/java/io/phasetwo/service/auth/idp/AbstractHomeIdpDiscoveryAuthenticatorFactory.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/AbstractHomeIdpDiscoveryAuthenticatorFactory.java
@@ -71,7 +71,7 @@ public abstract class AbstractHomeIdpDiscoveryAuthenticatorFactory implements Au
 
     @Override
     public final Authenticator create(KeycloakSession session) {
-        return new HomeIdpDiscoveryAuthenticator(discovererConfig);
+        return new HomeIdpDiscoveryAuthenticator(session, discovererConfig);
     }
 
     @Override

--- a/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoveryAuthenticator.java
+++ b/src/main/java/io/phasetwo/service/auth/idp/HomeIdpDiscoveryAuthenticator.java
@@ -4,13 +4,17 @@ package io.phasetwo.service.auth.idp;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
+import org.keycloak.WebAuthnConstants;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.FlowStatus;
 import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
+import org.keycloak.authentication.authenticators.browser.WebAuthnConditionalUIAuthenticator;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.*;
+import org.keycloak.models.credential.WebAuthnCredentialModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.services.managers.AuthenticationManager;
 
@@ -23,9 +27,11 @@ final class HomeIdpDiscoveryAuthenticator extends AbstractUsernameFormAuthentica
     private static final Logger LOG = Logger.getLogger(HomeIdpDiscoveryAuthenticator.class);
 
     private final AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig discovererConfig;
+    private final WebAuthnConditionalUIAuthenticator webauthnAuth;
 
-    HomeIdpDiscoveryAuthenticator(AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig discovererConfig) {
+    HomeIdpDiscoveryAuthenticator(KeycloakSession session, AbstractHomeIdpDiscoveryAuthenticatorFactory.DiscovererConfig discovererConfig) {
         this.discovererConfig = discovererConfig;
+        this.webauthnAuth = new WebAuthnConditionalUIAuthenticator(session, context -> createLoginForm(context.form()));
     }
 
     @Override
@@ -61,10 +67,12 @@ final class HomeIdpDiscoveryAuthenticator extends AbstractUsernameFormAuthentica
                 }
             } else {
                 //if no username hint force challenge
+                fillWebAuthnContextIfEnabled(authenticationFlowContext);
                 context.authenticationChallenge().forceChallenge();
             }
         } else {
             //if no bypass login force challenge
+            fillWebAuthnContextIfEnabled(authenticationFlowContext);
             context.authenticationChallenge().forceChallenge();
         }
     }
@@ -101,6 +109,27 @@ final class HomeIdpDiscoveryAuthenticator extends AbstractUsernameFormAuthentica
         }
 
         HomeIdpAuthenticationFlowContext context = new HomeIdpAuthenticationFlowContext(authenticationFlowContext);
+
+        if (webauthnAuth.isPasskeysEnabled()
+                && (formData.containsKey(WebAuthnConstants.AUTHENTICATOR_DATA) || formData.containsKey(WebAuthnConstants.ERROR))) {
+            // webauthn (passkey) form submission, try to action using the webauthn authenticator
+            webauthnAuth.action(authenticationFlowContext);
+            if (FlowStatus.SUCCESS != authenticationFlowContext.getStatus()) {
+                return;
+            }
+            // The passkey verified the user, but home IdP discovery still applies -- same as
+            // Keycloak's OrganizationAuthenticator, which keeps checking organizations after a
+            // successful passkey: a discovered home IdP overrides the local sign-in.
+            UserModel authenticated = authenticationFlowContext.getUser();
+            String authenticatedUsername =
+                    authenticated.getEmail() != null ? authenticated.getEmail() : authenticated.getUsername();
+            final List<IdentityProviderModel> discovered =
+                    context.discoverer(discovererConfig).discoverForUser(authenticationFlowContext, authenticatedUsername);
+            if (!discovered.isEmpty()) {
+                redirectOrChallenge(context, authenticatedUsername, discovered);
+            }
+            return;
+        }
 
         String tryUsername;
         if (context.reauthentication().required() && authenticationFlowContext.getUser() != null) {
@@ -171,6 +200,24 @@ final class HomeIdpDiscoveryAuthenticator extends AbstractUsernameFormAuthentica
                 username = null;
         }
         return username;
+    }
+
+    @Override
+    protected Response challenge(AuthenticationFlowContext context, String error, String field) {
+        fillWebAuthnContextIfEnabled(context);
+        return super.challenge(context, error, field);
+    }
+
+    // mirrors UsernamePasswordForm#isConditionalPasskeysEnabled: offer a passkey when the realm
+    // policy enables them and the identified user (if any) actually holds a passwordless credential
+    private void fillWebAuthnContextIfEnabled(AuthenticationFlowContext context) {
+        if (webauthnAuth.isPasskeysEnabled()
+                && (context.getUser() == null
+                        || context.getUser()
+                                .credentialManager()
+                                .isConfiguredFor(WebAuthnCredentialModel.TYPE_PASSWORDLESS))) {
+            webauthnAuth.fillContextForm(context);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #483.

## What

When a realm enables passkeys (WebAuthn Passwordless Policy → Enable Passkeys), `HomeIdpDiscoveryAuthenticator` now offers them on the username page, the way Keycloak's stock username forms do:

- **Before rendering the form** (and on error challenges), fill the WebAuthn context via Keycloak's public `WebAuthnConditionalUIAuthenticator` so the login theme renders the conditional-UI affordances (autofill + button). Gating mirrors stock `UsernamePasswordForm#isConditionalPasskeysEnabled`: realm policy on, and the identified user (if any) actually holds a passwordless credential. The theme needs no changes — everything downstream keys on `enableWebAuthnConditionalUI`.
- **In `action()`**, submissions carrying `WebAuthnConstants.AUTHENTICATOR_DATA`/`ERROR` are a passkey assertion posting back to this authenticator; they're delegated to `WebAuthnConditionalUIAuthenticator.action()`. On success the passwordless credential is recorded and a later `UsernamePasswordForm` skips itself.

## Design note: discovery still applies after a passkey

The delegation is deliberately **not** an early return. After a successful assertion, discovery runs for the authenticated user, and a discovered home IdP still redirects — a locally registered passkey does not become a bypass of IdP enforcement (otherwise a user deactivated at their IdP could keep signing in locally indefinitely). This mirrors Keycloak's own `OrganizationAuthenticator`, which continues checking organizations — including the broker redirect — after a successful passkey; overriding the post-success flow status is the stock pattern there.

This goes slightly beyond what the issue originally sketched (plain delegation); the interaction with IdP enforcement surfaced while we validated our derivative, so it's addressed here rather than left as a follow-up. Happy to split or adjust if you'd rather keep this PR minimal.

## Notes

- `getCredentialType()` is protected in `WebAuthnPasswordlessAuthenticator` (package-private access is why stock forms can call it), so the constant it returns, `WebAuthnCredentialModel.TYPE_PASSWORDLESS`, is used directly.
- Everything is guarded by `isPasskeysEnabled()` (feature + realm policy), so realms without passkeys enabled behave exactly as before.
- `WebAuthnConditionalUIAuthenticator` requires a recent Keycloak; this branch targets the repo's current 26.6.3. If you support older Keycloak lines from this branch, this may need guarding — happy to adjust.

## Testing

Formatted with Spotless and compiled against this repo. Behavior was verified end-to-end in our derivative of this authenticator (same wiring, adapted names) against a live Keycloak 26.6.4: conditional-UI autofill and button on the username page, passkey sign-in with the password step skipped (`credential_type=webauthn-passwordless` LOGIN events), post-assertion discovery redirecting to a real brokered IdP (Microsoft Entra ID) instead of creating a local session, and no behavioral change with the realm policy off. I did not run this repo's Cypress suite; happy to add coverage there if you want it.

Disclosure: developed with AI assistance (Claude); the analysis and behavior described were verified by a human against live Keycloak deployments.
