### PR TITLE
Return 204 from active-organization when user has no organization

### DIFF
--- a/src/main/java/io/phasetwo/service/resource/UserResource.java
+++ b/src/main/java/io/phasetwo/service/resource/UserResource.java
@@ -1,7 +1,9 @@
 package io.phasetwo.service.resource;
 
 import static io.phasetwo.service.Orgs.ACTIVE_ORGANIZATION;
-import static io.phasetwo.service.resource.Converters.*;
+import static io.phasetwo.service.resource.Converters.convertInvitationModelToInvitation;
+import static io.phasetwo.service.resource.Converters.convertOrganizationModelToOrganization;
+import static io.phasetwo.service.resource.Converters.convertOrganizationRole;
 import static io.phasetwo.service.resource.OrganizationResourceType.ORGANIZATION_ROLE_MAPPING;
 import static org.keycloak.events.EventType.UPDATE_PROFILE;
 
@@ -15,7 +17,16 @@ import io.phasetwo.service.representation.SwitchOrganization;
 import io.phasetwo.service.util.ActiveOrganization;
 import io.phasetwo.service.util.TokenManager;
 import jakarta.validation.Valid;
-import jakarta.ws.rs.*;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
@@ -138,15 +149,19 @@ public class UserResource extends OrganizationAdminResource {
   @GET
   @Path("/active-organization")
   @Produces(MediaType.APPLICATION_JSON)
-  public Organization getActiveOrganization() {
+  public Response getActiveOrganization() {
     ActiveOrganization activeOrganizationUtil =
         ActiveOrganization.fromContext(session, realm, auth.getUser());
 
+    // A user who belongs to no organization has nothing active. That is not an
+    // authorization failure, so report it as an empty result.
     if (!activeOrganizationUtil.isValid()) {
-      throw new NotAuthorizedException("Action not allowed.");
+      return Response.noContent().build();
     }
 
-    return convertOrganizationModelToOrganization(activeOrganizationUtil.getOrganization());
+    return Response.ok(
+            convertOrganizationModelToOrganization(activeOrganizationUtil.getOrganization()))
+        .build();
   }
 
   @PUT

--- a/src/test/java/io/phasetwo/service/resource/OrganizationResourceTest.java
+++ b/src/test/java/io/phasetwo/service/resource/OrganizationResourceTest.java
@@ -2105,7 +2105,7 @@ class OrganizationResourceTest extends AbstractOrganizationTest {
 
     // Get active organization with no organization membership
     Response response = getRequest(kc, "users", "active-organization");
-    assertThat(response.getStatusCode(), is(Status.UNAUTHORIZED.getStatusCode()));
+    assertThat(response.getStatusCode(), is(Status.NO_CONTENT.getStatusCode()));
 
     // Add user to org1
     putRequest("pass", org1Id, "members", user.getId());


### PR DESCRIPTION
Closes #485 (second half — the schema drift was fixed in p2-inc/phasetwo-docs#350).

Per @xgp on [#485](https://github.com/p2-inc/keycloak-orgs/issues/485#issuecomment-5480865550), `204` is the preferred behaviour.

### The problem

`GET /{realm}/users/active-organization` threw `NotAuthorizedException` — a `401` — whenever `ActiveOrganization#isValid()` was false:

```java
if (!activeOrganizationUtil.isValid()) {
  throw new NotAuthorizedException("Action not allowed.");
}
```

`isValid()` is just `organization != null`, and `ActiveOrganization` falls back to the user's first organization when no `active_organization` attribute is set. So the null case is reached precisely when the user belongs to **no organization at all**. That user isn't unauthorized — they simply have nothing active. `openapi.yaml` has always documented `204: No active organization set` for it, so this brings the implementation in line with the published contract rather than the other way round.

### The change

`getActiveOrganization()` now returns `Response` so it can express both outcomes: `204 No Content` when there's no active organization, and the unchanged `Organization` body on `200`.

The existing coverage in `OrganizationResourceTest` already exercises this path — it asserted `UNAUTHORIZED` for the no-membership case, now `NO_CONTENT`. The rest of that test (the `200`s after joining an org, switching, and the malicious-switch case) is untouched and should still pass.

### Note on the import churn

The diff is larger than the behaviour change because `oss-parent` configures Spotless with `ratchetFrom origin/main` and `forbidWildcardImports`, bound to the `compile` phase. `UserResource.java` had two pre-existing wildcard imports (`Converters.*` and `jakarta.ws.rs.*`); editing the file pulls it into the ratchet, and Spotless can't auto-fix those, so `mvn verify` fails until they're expanded. They're expanded to exactly the symbols javac asks for — no other changes.

### Verification

- `mvn compile`, `mvn test-compile`, and `mvn spotless:check` all pass locally.
- The integration suite needs Docker, which I don't have available here, so **the `OrganizationResourceTest` assertion change is unverified locally** — relying on CI for that.

### Breaking change

Any client currently treating `401` from this endpoint as "no active organization" will need to handle `204`. Given the spec documented `204` all along, clients coded against the docs are more likely to be fixed than broken by this — but it is a behaviour change on a public endpoint and worth a release note.